### PR TITLE
Add Battle Mode Detection & Improved F1 Leaderboard (Discovered Project via TikTok)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,23 @@
 
+.venv/
+venv/
+env/
+ENV/
 
-output_animation.mp4
-.fastf1-cache
-still_frame.png
 
 __pycache__/
+*.pyc
+*.pyo
+*.pyd
 
-computed_data/
 
 .DS_Store
+
+
+.fastf1-cache/
+computed_data/
+output_animation.mp4
+still_frame.png
+
+
+.vscode/


### PR DESCRIPTION
Hi Tom!

I came across your project on TikTok and was genuinely impressed. The concept of a full F1 race replay with real telemetry is brilliant, and I immediately wanted to contribute. I took some time to explore the codebase and built a feature that I think fits naturally with the spirit of the project.

This PR introduces a “Battle Mode” enhancement to the replay experience.

The main reasons of this addition
	•	It brings the replay closer to how F1 TV / live timing present race data
	•	Makes it much easier to spot wheel-to-wheel battles during playback
	•	Adds depth without changing the core replay functionality
	•	Enhances user experience while preserving your original design

The updated files are:
	•	src/f1_data.py — extended frame data, added battle detection & gap-to-leader logic
	•	src/arcade_replay.py — redesigned leaderboard UI layout to incorporate battle/gap info
	•	.gitignore — improved to exclude virtual environments, FastF1 cache, and generated data

Thanks for open-sourcing this — it’s a genuinely cool project and inspired me to dive in.
I’d be happy to keep contributing and expanding the replay features if you’re open to collaboration.

Excited to hear your thoughts!

Rawad