### PR TITLE
Playback Speed Indicator

### DIFF
--- a/src/arcade_replay.py
+++ b/src/arcade_replay.py
@@ -221,7 +221,7 @@ class F1ReplayWindow(arcade.Window):
                          20, self.height - 40, 
                          arcade.color.WHITE, 24, anchor_y="top").draw()
         
-        arcade.Text(f"Race Time: {time_str}", 
+        arcade.Text(f"Race Time: {time_str} (x{self.playback_speed})", 
                          20, self.height - 80, 
                          arcade.color.WHITE, 20, anchor_y="top").draw()
         


### PR DESCRIPTION
Hi! 
This is a teeny tiny PR that adds an indicator for the current playback speed, as this is not directly apparent when changing speed via the arrowkeys. 
<img width="368" height="106" alt="Screenshot from 2025-11-30 16-44-24" src="https://github.com/user-attachments/assets/c5486e25-aee2-4369-b96c-48dd2589ec7f" />
As a side-note, I considered changing the minimum playback speed to 0.125 to avoid losing the ability to go back to 1x using the arrow-keys, but I decided to keep this out of this tiny PR. Not sure if this is something you would prefer. 
Thanks for this cool project and your encouragement for new coders. Cheers!