### PR TITLE
Limit playback speed controls to valid presets (0.5x-4.0x)

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -398,9 +398,11 @@ class F1RaceReplayWindow(arcade.Window):
         elif symbol == arcade.key.LEFT:
             self.frame_index = max(self.frame_index - 10.0, 0.0)
         elif symbol == arcade.key.UP:
-            self.playback_speed *= 2.0
+            if self.playback_speed < 4.0:
+                self.playback_speed *= 2.0
         elif symbol == arcade.key.DOWN:
-            self.playback_speed = max(0.1, self.playback_speed / 2.0)
+            if self.playback_speed > 0.5:
+                self.playback_speed /= 2.0
         elif symbol == arcade.key.KEY_1:
             self.playback_speed = 0.5
         elif symbol == arcade.key.KEY_2:


### PR DESCRIPTION
## Description 
Fixed an issue where the up/down arrow key speed controls had no upper or lower bounds, allowing users to increase or decrease playback speed to any power of 2 indefinitely.

## Changes
Up arrow now only increases speed when below 4.0x (maximum)
Down arrow now only decreases speed when above 0.5x (minimum)
Valid Speed Presets

* 0.5x
* 1.0x
* 2.0x
* 4.0x

<img width="1512" height="788" alt="Screenshot 2025-12-10 at 22 36 11" src="https://github.com/user-attachments/assets/525c89b0-8a24-450f-bf48-e0adcd081386" />
