### PR TITLE
Adjust minimum playback speed in race replay

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -400,7 +400,7 @@ class F1RaceReplayWindow(arcade.Window):
         elif symbol == arcade.key.UP:
             self.playback_speed *= 2.0
         elif symbol == arcade.key.DOWN:
-            self.playback_speed = max(0.1, self.playback_speed / 2.0)
+            self.playback_speed = max(0.125, self.playback_speed / 2.0)
         elif symbol == arcade.key.KEY_1:
             self.playback_speed = 0.5
         elif symbol == arcade.key.KEY_2:


### PR DESCRIPTION
Changed the minimum playback speed from 0.1 to 0.125 when decreasing speed with the DOWN key to ensure it goes back to 1x when increasing, instead of 0.8x and 1.6x