### PR TITLE
Feature: Add Last Lap Time and Interval Gaps to Race Replay Leaderboard

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -13,7 +13,7 @@ SCREEN_TITLE = "F1 Replay"
 class F1RaceReplayWindow(arcade.Window):
     def __init__(self, frames, track_statuses, example_lap, drivers, title,
                  playback_speed=1.0, driver_colors=None, circuit_rotation=0.0,
-                 left_ui_margin=340, right_ui_margin=260, total_laps=None):
+                 left_ui_margin=340, right_ui_margin=420, total_laps=None):
         # Set resizable to True so the user can adjust mid-sim
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, title, resizable=True)
 
@@ -38,7 +38,8 @@ class F1RaceReplayWindow(arcade.Window):
         self.right_ui_margin = right_ui_margin
         # UI components
         leaderboard_x = max(20, self.width - self.right_ui_margin + 12)
-        self.leaderboard_comp = LeaderboardComponent(x=leaderboard_x, width=240)
+        # Explicitly set width to 400
+        self.leaderboard_comp = LeaderboardComponent(x=leaderboard_x, width=400)
         self.weather_comp = WeatherComponent(left=20, top_offset=170)
         self.legend_comp = LegendComponent(x=max(12, self.left_ui_margin - 320))
         self.driver_info_comp = DriverInfoComponent(left=20, width=300)
@@ -352,7 +353,14 @@ class F1RaceReplayWindow(arcade.Window):
         for code, pos in frame["drivers"].items():
             color = self.driver_colors.get(code, arcade.color.WHITE)
             progress_m = driver_progress.get(code, float(pos.get("dist", 0.0)))
-            driver_list.append((code, color, pos, progress_m))
+            
+            # Use .get with a default value to handle cases where cached data is old or missing
+            last_lap = pos.get("last_lap_time_str", "---")
+            interval = pos.get("interval_str", "---")
+            
+            # Pass all 6 required elements to the leaderboard
+            driver_list.append((code, color, pos, progress_m, last_lap, interval))
+        
         driver_list.sort(key=lambda x: x[3], reverse=True)
         self.leaderboard_comp.set_entries(driver_list)
         self.leaderboard_comp.draw(self)


### PR DESCRIPTION

<img width="1512" height="949" alt="Screenshot 2025-12-15 at 8 52 33 PM" src="https://github.com/user-attachments/assets/7a04b84d-8786-4dae-a989-6d199d139fbf" />


## Description

This PR enhances the Race Replay UI by adding two critical data points to the leaderboard: **Last Lap Time** and **Interval** (time gap to the car ahead). This brings the replay experience closer to a real F1 broadcast.

Previously, the leaderboard only showed positions and tire compounds. Now, it calculates real-time gaps in seconds (interpolated from telemetry data) and displays the most recent lap time for every driver.

## Changes Overview

### 1. Data Processing (`src/f1_data.py`)

**Added Last Lap Logic:**
- Modified `_process_single_driver` to capture the `LapTime` of the previous lap and forward-fill it into the current lap's telemetry frames.

**Added Interval Calculation:**
- Updated `get_race_telemetry` to calculate the time gap (in seconds) between cars.
- **Logic:** It uses `np.interp` to find the exact timestamp when the "car ahead" was at the "current car's" current distance, then calculates the difference (`current_time - time_ahead_was_here`).

**Frame Payload:**
- Updated the frame structure to include `last_lap_time_str` and `interval_str` for every driver.

### 2. UI Components (`src/ui_components.py`)

**Widened Leaderboard:**
- Increased `LeaderboardComponent` width from 240px to 400px to accommodate the new columns.

**New Headers:**
- Added a header row for POS / DRV, LAP TIME, and INTERVAL.

**Rendering:**
- Updated the `draw()` method to render the new `last_lap_time` (center-aligned) and `interval` (right-aligned) text strings.

### 3. Race Replay Interface (`src/interfaces/race_replay.py`)

**Window Layout:**
- Increased the `right_ui_margin` from 260 to 420 to fit the wider leaderboard without overlapping the track.

**Data Passing:**
- Updated `on_draw` to extract the new fields (`last_lap_time_str`, `interval_str`) from the frame data and pass them as a 6-item tuple to the `LeaderboardComponent`.

## How to Test

Run the replay with the `--refresh-data` flag to regenerate the cache with the new metrics:

```bash
python main.py --year 2024 --round 1 --refresh-data
```

Observe the leaderboard on the right side; it should now display lap times and intervals.