### PR TITLE
Fix: Add sys.exit(0) after --list-rounds and --list-sprints flags

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,8 +81,10 @@ if __name__ == "__main__":
 
   if "--list-rounds" in sys.argv:
     list_rounds(year)
+    sys.exit(0)
   elif "--list-sprints" in sys.argv:
     list_sprints(year)
+    sys.exit(0)
 
   playback_speed = 1
 


### PR DESCRIPTION
Fix for issue: [54]

### Changes
- Added `sys.exit(0)` after `list_rounds()` and `list_sprints()` calls
- Program now exits cleanly after listing rounds/sprints
- Prevents unnecessary execution of main() function

