### PR TITLE
Cleaning up unused options and converting to argparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from src.arcade_replay import run_arcade_replay
 from src.interfaces.qualifying import run_qualifying_replay
 from datetime import date
 import argparse
-import sys
 
 def main(year=None, round_number=None, playback_speed=1, session_type='R'):
   print(f"Loading F1 {year} Round {round_number} Session '{session_type}'")
@@ -49,9 +48,6 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R'):
 
     # Run the arcade replay
 
-    # Check for optional chart flag
-    chart = "--chart" in sys.argv
-
     run_arcade_replay(
         frames=race_telemetry['frames'],
         track_statuses=race_telemetry['track_statuses'],
@@ -62,7 +58,6 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R'):
         title=f"{session.event['EventName']} - {'Sprint' if session_type == 'S' else 'Race'}",
         total_laps=race_telemetry['total_laps'],
         circuit_rotation=circuit_rotation,
-        chart=chart,
     )
 
 if __name__ == "__main__":

--- a/src/arcade_replay.py
+++ b/src/arcade_replay.py
@@ -8,7 +8,7 @@ SCREEN_HEIGHT = 1200
 SCREEN_TITLE = "F1 Race Replay"
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
-                      playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None, chart=False):
+                      playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None):
     window = F1RaceReplayWindow(
         frames=frames,
         track_statuses=track_statuses,


### PR DESCRIPTION
Cleaned up the *--chart* option:
- It is never used outside of the run_arcade_replay() function definition
- It didn't seem to do anything anyways
- It was also being checked for directly inside main(), which was the wrong place for it anyways

Replaced argument parsing with argparse:
- It is cleaner
- It provides the -h/--help option with a nicely formatted help, which makes for a better user experience
- It also implements shortened options, such as -y for --year, -r for --round, etc.
- I separated the listing and session type sections into their own groups
- I changed the default year to be based on date.today(), so it defaults to the current year regardless of the year (also, help reflects this as it displays the same value)