### PR TITLE
Add argparse-based CLI with built-in help and validated flags

### DIFF
--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import fastf1
 import fastf1.plotting
 from multiprocessing import Pool, cpu_count
@@ -155,7 +154,7 @@ def get_circuit_rotation(session):
     circuit = session.get_circuit_info()
     return circuit.rotation
 
-def get_race_telemetry(session, session_type='R'):
+def get_race_telemetry(session, session_type='R', refresh_data=False):
 
     event_name = str(session).replace(' ', '_')
     cache_suffix = 'sprint' if session_type == 'S' else 'race'
@@ -163,7 +162,7 @@ def get_race_telemetry(session, session_type='R'):
     # Check if this data has already been computed
 
     try:
-        if "--refresh-data" not in sys.argv:
+        if not refresh_data:
             with open(f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "rb") as f:
                 frames = pickle.load(f)
                 print(f"Loaded precomputed {cache_suffix} telemetry data.")
@@ -753,7 +752,7 @@ def _process_quali_driver(args):
     }
 
 
-def get_quali_telemetry(session, session_type='Q'):
+def get_quali_telemetry(session, session_type='Q', refresh_data=False):
     # This function is going to get the results from qualifying and the telemetry for each drivers' fastest laps in each qualifying segment
 
     # The structure of the returned data will be:
@@ -774,7 +773,7 @@ def get_quali_telemetry(session, session_type='Q'):
 
     # Check if this data has already been computed
     try:
-        if "--refresh-data" not in sys.argv:
+        if not refresh_data:
             with open(f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "rb") as f:
                 data = pickle.load(f)
                 print(f"Loaded precomputed {cache_suffix} telemetry data.")


### PR DESCRIPTION
**Description**
This PR introduces a proper command-line interface using argparse to improve usability and maintainability of the tool.

**What changed**

1. Replaced manual sys.argv parsing with argparse.
2. Added automatic --help output with clear flag descriptions.
3. Centralized CLI argument parsing at the program entry point.
4. Kept existing runtime behavior and replay logic unchanged.

**Why**

1. Makes the tool self-documenting via --help.
2. Aligns CLI handling with common open-source conventions.

**Example Usage**

<img width="1283" height="340" alt="argeparse-usage-snapshot" src="https://github.com/user-attachments/assets/083a29c2-9757-464a-bd73-469f6fc4f624" />
