### PR TITLE
fix typos and grammatical errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ f1-race-replay/
 
 ## Contributing
 
-There have been serveral contributions from the community that have helped enhance this project. I have added a [contributors.md](./contributors.md) file to acknowledge those who have contributed features and improvements.
+There have been several contributions from the community that have helped enhance this project. I have added a [contributors.md](./contributors.md) file to acknowledge those who have contributed features and improvements.
 
 If you would like to contribute, feel free to:
 
@@ -122,7 +122,7 @@ Please see [roadmap.md](./roadmap.md) for planned features and project vision.
 
 # Known Issues
 
-- The leaderboard appears to be inaccurate for the first few corners of the race. The leaderboard is also temporarily affected by a driver going in the pits. At the end of the race the leadeboard is sometimes affected by the drivers final x,y positions being further ahead than other drivers. These issues are known issues caused by innacuracies in the telemetry and being worked on for future releases. Its likely that these issues will be fixed in stages as improving the leaderboard accuracy is a complex task.
+- The leaderboard appears to be inaccurate for the first few corners of the race. The leaderboard is also temporarily affected by a driver going in the pits. At the end of the race, the leaderboard is sometimes affected by the drivers' final x,y positions being further ahead than other drivers. These are known issues caused by inaccuracies in the telemetry and are being worked on for future releases. It's likely that these issues will be fixed in stages as improving the leaderboard accuracy is a complex task.
 
 ## 📝 License
 


### PR DESCRIPTION
Corrected spelling errors in the Contributing and Known Issues sections:
- Fixed "serveral" to "several"
- Fixed "leadeboard" to "leaderboard"
- Fixed "innacuracies" to "inaccuracies"

Improved grammar and flow in Known Issues:
- Added missing auxiliary verb ("are being worked on")
- Fixed possessive case ("drivers'" final positions)
- Added missing punctuation for better readability