### PR TITLE
Support country-based session lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ To return a list of events that include Sprint sessions, use the `--list-sprints
 python main.py --year 2025 --list-sprints
 ```
 
+### Search Country (including Sprints)
+
+You can also select an event by country name instead of providing a round number. If `--round` is omitted and `--country` is provided, the application will attempt to find the event matching that country for the given year and load it.
+
+Examples:
+```bash
+python main.py --year 2025 --country australia
+python main.py --year 2025 --country australia --qualifying
+```
+
+Notes:
+- If both `--round` and `--country` are provided, `--round` takes priority.
+- Use `--list-rounds` or `--list-sprints` to find the exact round numbers when needed.
+
+
 ### Qualifying Session Replay
 
 To run a Qualifying session replay, use the `--qualifying` flag:

--- a/main.py
+++ b/main.py
@@ -4,9 +4,9 @@ from src.arcade_replay import run_arcade_replay
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
 
-def main(year=None, round_number=None, playback_speed=1, session_type='R'):
-  print(f"Loading F1 {year} Round {round_number} Session '{session_type}'")
-  session = load_session(year, round_number, session_type)
+def main(year=None, country=None, round_number=None, playback_speed=1, session_type='R'):
+  print(f"Loading F1 {year} Round {round_number if round_number is not None else country} Session {session_type}")
+  session = load_session(year, country=country, round_number=round_number, session_type=session_type)
 
   print(f"Loaded session: {session.event['EventName']} - {session.event['RoundNumber']} - {session_type}")
 
@@ -41,7 +41,7 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R'):
     
     try:
         print("Attempting to load qualifying session for track layout...")
-        quali_session = load_session(year, round_number, 'Q')
+        quali_session = load_session(year, country=country, round_number=round_number, session_type='Q')
         if quali_session is not None and len(quali_session.laps) > 0:
             fastest_quali = quali_session.laps.pick_fastest()
             if fastest_quali is not None:
@@ -95,12 +95,18 @@ if __name__ == "__main__":
     year = int(sys.argv[year_index])
   else:
     year = 2025  # Default year
+  
+  if "--country" in sys.argv:
+    country_index = sys.argv.index("--country") + 1
+    country = sys.argv[country_index]
+  else:
+    country = None
 
   if "--round" in sys.argv:
     round_index = sys.argv.index("--round") + 1
     round_number = int(sys.argv[round_index])
   else:
-    round_number = 12  # Default round number
+    round_number = None  # Default round number
 
   if "--list-rounds" in sys.argv:
     list_rounds(year)
@@ -113,4 +119,4 @@ if __name__ == "__main__":
     # Session type selection
     session_type = 'SQ' if "--sprint-qualifying" in sys.argv else ('S' if "--sprint" in sys.argv else ('Q' if "--qualifying" in sys.argv else 'R'))
     
-    main(year, round_number, playback_speed, session_type=session_type)
+    main(year=year, country=country, round_number=round_number, playback_speed=playback_speed, session_type=session_type)

--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -132,9 +132,23 @@ def _process_single_driver(args):
         "max_lap": driver_max_lap
     }
 
-def load_session(year, round_number, session_type='R'):
-    # session_type: 'R' (Race), 'S' (Sprint) etc.
-    session = fastf1.get_session(year, round_number, session_type)
+def load_session(year, country=None, round_number=None, session_type='R'):
+    """
+    If `round_number` is provided (not None), it will be used as the `gp`
+    Otherwise `country` (a string) will be used and FastF1's fuzzy matching resolves the event.
+    session_type: 'R' (Race), 'S' (Sprint) etc.
+    """
+    enable_cache()
+
+    # Prefer explicit round number when provided
+    if round_number is not None:
+        gp = round_number
+    else:
+        if country is None:
+            raise ValueError("Either `round_number` or `country` must be provided to load_session")
+        gp = country
+
+    session = fastf1.get_session(year, gp, session_type)
     session.load(telemetry=True, weather=True)
     return session
 


### PR DESCRIPTION
Add support for selecting an event by --country when --round is omitted. Keeps explicit --round behaviour unchanged, and it still takes precedence, so old users won't have any difficulties.

Critiques and changes are much appreciated.