### PR TITLE
Fix leaderboard incorrect positions at race start (Fixes #63)

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -337,6 +337,15 @@ class F1RaceReplayWindow(arcade.Window):
 
             # Project (x,y) to reference and combine with lap count
             projected_m = self._project_to_reference(pos.get("x", 0.0), pos.get("y", 0.0))
+
+            # Fix for start-line wrap-around:
+            # If on Lap 1, and telemetry distance suggests we are near start (e.g. < 50% lap),
+            # but projection suggests we are near end (> 50% lap), it means we are behind the line.
+            # We subtract lap length to make progress negative (e.g. -10m instead of 4990m).
+            telemetry_dist = float(pos.get("dist", 0.0))
+            if lap == 1 and telemetry_dist < self._ref_total_length * 0.5 and projected_m > self._ref_total_length * 0.5:
+                projected_m -= self._ref_total_length
+
             # progress in metres since race start: (lap-1) * lap_length + projected_m
             progress_m = float((max(lap, 1) - 1) * self._ref_total_length + projected_m)
 


### PR DESCRIPTION
Problem Description
The leaderboard was showing incorrect driver positions at the start of the race. Drivers on the grid (physically behind the start line) were being projected to the end of the lap (e.g., 4990m on a 5000m track) because the track projection logic treats the track as a closed loop. This caused backmarkers on the grid to appear as having completed nearly a full lap (Progress: 4990m) compared to the leader who had just crossed the start line (Progress: 10m).

<img width="746" height="425" alt="image" src="https://github.com/user-attachments/assets/5bd89c1e-a80e-47d0-aef7-2ccbd3816c9b" />

Verification Results
Logic Check
Scenario 1: Car on Grid (Lap 1)

telemetry_dist: 0m (or close to 0)
projected_m: 4950m (Track Length: 5000m)
Old Result: progress_m = 4950m. (Incorrectly viewed as ahead of leader)
New Result: telemetry_dist (0) < 2500m AND projected_m (4950) > 2500m. Condition Met.
projected_m becomes 4950 - 5000 = -50m.
progress_m = -50m. (Correctly viewed as behind leader)
Scenario 2: Car crossed start line (Lap 1)

telemetry_dist: 10m
projected_m: 10m
New Result: Condition projected_m (10) > 2500m is False.
progress_m = 10m.
Scenario 3: End of Lap 1 (Approaching finish)

telemetry_dist: 4950m
projected_m: 4950m
New Result: Condition telemetry_dist (4950) < 2500m is False.
progress_m = 4950m. (Correct)
Automated Tests
Ran python -m py_compile to verify syntax correctness.