### PR TITLE
Basic GUI Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ To get started with this project locally, you can follow these steps:
 
 ## Usage
 
+**NEW GUI MENU:** To use the new GUI menu system, you can simply run:
+```bash
+python main.py --gui
+```
+This will open a graphical interface where you can select the year and round of the race weekend you want to replay. This is still a new feature, so please report any issues you encounter.
+
 Run the main script and specify the year and round:
 ```bash
 python main.py --year 2025 --round 12

--- a/main.py
+++ b/main.py
@@ -3,8 +3,10 @@ from src.arcade_replay import run_arcade_replay
 
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
+from src.gui.race_selection import RaceSelectionWindow
+from PySide6.QtWidgets import QApplication
 
-def main(year=None, round_number=None, playback_speed=1, session_type='R', visible_hud=True):
+def main(year=None, round_number=None, playback_speed=1, session_type='R', visible_hud=True, ready_file=None):
   print(f"Loading F1 {year} Round {round_number} Session '{session_type}'")
   session = load_session(year, round_number, session_type)
 
@@ -27,6 +29,7 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
       session=session,
       data=qualifying_session_data,
       title=title,
+      ready_file=ready_file,
     )
 
   else:
@@ -71,19 +74,26 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
     # Run the arcade replay
 
     run_arcade_replay(
-        frames=race_telemetry['frames'],
-        track_statuses=race_telemetry['track_statuses'],
-        example_lap=example_lap,
-        drivers=drivers,
-        playback_speed=playback_speed,
-        driver_colors=race_telemetry['driver_colors'],
-        title=f"{session.event['EventName']} - {'Sprint' if session_type == 'S' else 'Race'}",
-        total_laps=race_telemetry['total_laps'],
-        circuit_rotation=circuit_rotation,
-        visible_hud=visible_hud
+      frames=race_telemetry['frames'],
+      track_statuses=race_telemetry['track_statuses'],
+      example_lap=example_lap,
+      drivers=drivers,
+      playback_speed=playback_speed,
+      driver_colors=race_telemetry['driver_colors'],
+      title=f"{session.event['EventName']} - {'Sprint' if session_type == 'S' else 'Race'}",
+      total_laps=race_telemetry['total_laps'],
+      circuit_rotation=circuit_rotation,
+      visible_hud=visible_hud
+      ,ready_file=ready_file
     )
 
 if __name__ == "__main__":
+
+  if "--gui" in sys.argv:
+    app = QApplication(sys.argv)
+    win = RaceSelectionWindow()
+    win.show()
+    sys.exit(app.exec())
 
   # Get the year and round number from user input
 
@@ -112,5 +122,12 @@ if __name__ == "__main__":
 
   # Session type selection
   session_type = 'SQ' if "--sprint-qualifying" in sys.argv else ('S' if "--sprint" in sys.argv else ('Q' if "--qualifying" in sys.argv else 'R'))
-  
-  main(year, round_number, playback_speed, session_type=session_type, visible_hud=visible_hud)
+
+  # Optional ready-file path used when spawned from the GUI to signal ready state
+  ready_file = None
+  if "--ready-file" in sys.argv:
+    idx = sys.argv.index("--ready-file") + 1
+    if idx < len(sys.argv):
+      ready_file = sys.argv[idx]
+
+  main(year, round_number, playback_speed, session_type=session_type, visible_hud=visible_hud, ready_file=ready_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 numpy
 arcade
 pyglet
+pyside6

--- a/src/arcade_replay.py
+++ b/src/arcade_replay.py
@@ -9,7 +9,7 @@ SCREEN_TITLE = "F1 Race Replay"
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
                       playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None,
-                      visible_hud=True):
+                      visible_hud=True, ready_file=None):
     window = F1RaceReplayWindow(
         frames=frames,
         track_statuses=track_statuses,
@@ -22,4 +22,11 @@ def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
         circuit_rotation=circuit_rotation,
         visible_hud=visible_hud,
     )
+    # Signal readiness to parent process (if requested) after window created
+    if ready_file:
+        try:
+            with open(ready_file, 'w') as f:
+                f.write('ready')
+        except Exception:
+            pass
     arcade.run()

--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -835,6 +835,23 @@ def get_quali_telemetry(session, session_type='Q'):
     }
 
 
+def get_race_weekends_by_year(year):
+    """Returns a list of race weekends for a given year."""
+    enable_cache()
+    schedule = fastf1.get_event_schedule(year)
+    weekends = []
+    for _, event in schedule.iterrows():
+        if event.is_testing():
+            continue
+        weekends.append({
+            "round_number": event['RoundNumber'],
+            "event_name": event['EventName'],
+            "date": str(event['EventDate'].date()),
+            "country": event['Country'],
+            "type": event['EventFormat'],
+        })
+    return weekends
+
 def list_rounds(year):
     """Lists all rounds for a given year."""
     enable_cache()

--- a/src/gui/race_selection.py
+++ b/src/gui/race_selection.py
@@ -1,0 +1,327 @@
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QComboBox, QPushButton, QTreeWidget, QTreeWidgetItem, QMessageBox, QInputDialog
+)
+from PySide6.QtWidgets import QProgressDialog
+from PySide6.QtCore import QThread, Signal, Qt, QTimer
+from PySide6.QtGui import QPixmap, QFont
+import sys
+import os
+import subprocess
+import tempfile
+import uuid
+from src.f1_data import get_race_weekends_by_year, load_session
+
+# Worker thread to fetch schedule without blocking UI
+class FetchScheduleWorker(QThread):
+    result = Signal(object)
+    error = Signal(str)
+
+    def __init__(self, year, parent=None):
+        super().__init__(parent)
+        self.year = year
+
+    def run(self):
+        try:
+            # enable cache if available in project
+            try:
+                from src.f1_data import enable_cache
+                enable_cache()
+            except Exception:
+                pass
+            events = get_race_weekends_by_year(self.year)
+            self.result.emit(events)
+        except Exception as e:
+            self.error.emit(str(e))
+
+class RaceSelectionWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.worker = None
+        self.loading_session = False
+        self.selected_session_title = None
+
+        self.setWindowTitle("F1 Race Replay - Session Selection")
+        self._setup_ui()
+        self.resize(1000, 700)
+        self.setMinimumSize(800, 600)
+        self.setWindowState(self.windowState())
+
+    def _setup_ui(self):
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+
+        main_layout = QVBoxLayout()
+        central_widget.setLayout(main_layout)
+
+        # Header (title)
+        header_layout = QHBoxLayout()
+        header_label = QLabel("F1 Race Replay 🏎️")
+        font = header_label.font()
+        font.setPointSize(18)
+        font.setBold(True)
+        header_label.setFont(font)
+        header_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        
+        header_layout.addWidget(header_label)
+        header_layout.addStretch()
+        main_layout.addLayout(header_layout)
+
+        # Year selection
+        year_layout = QHBoxLayout()
+        year_label = QLabel("Select Year:")
+        self.year_combo = QComboBox()
+        current_year = 2025  # Update as needed
+        for year in range(2010, current_year + 1):
+            self.year_combo.addItem(str(year))
+        self.year_combo.setCurrentText(str(current_year))
+        self.year_combo.currentTextChanged.connect(self.load_schedule)
+
+        year_layout.addWidget(year_label)
+        year_layout.addWidget(self.year_combo)
+        main_layout.addLayout(year_layout)
+
+        # Main content: left = schedule, right = session list
+        content_layout = QHBoxLayout()
+
+        # Schedule tree (left)
+        self.schedule_tree = QTreeWidget()
+        self.schedule_tree.setHeaderLabels(["Round", "Event","Country", "Start Date"])
+        self.schedule_tree.setRootIsDecorated(False)
+        content_layout.addWidget(self.schedule_tree, 3)
+        self.schedule_tree.setColumnWidth(2, 180)
+
+        # Session panel (right)
+        self.session_panel = QWidget()
+        self.session_panel_layout = QVBoxLayout()
+        self.session_panel.setLayout(self.session_panel_layout)
+        self.session_panel_layout.setAlignment(Qt.AlignTop)
+        header_lbl = QLabel("Sessions")
+        hdr_font = header_lbl.font()
+        hdr_font.setPointSize(14)
+        hdr_font.setBold(True)
+        header_lbl.setFont(hdr_font)
+        self.session_panel_layout.addWidget(header_lbl)
+
+        # placeholder spacer
+        self.session_list_container = QWidget()
+        self.session_list_layout = QVBoxLayout()
+        self.session_list_container.setLayout(self.session_list_layout)
+        self.session_panel_layout.addWidget(self.session_list_container)
+
+        content_layout.addWidget(self.session_panel, 1)
+
+        main_layout.addLayout(content_layout)
+
+        # connect click handler
+        self.schedule_tree.itemClicked.connect(self.on_race_clicked)
+
+        # Load initial schedule
+        # hide sessions panel until a weekend is selected
+        self.session_panel.hide()
+        self.load_schedule(str(current_year))
+        
+    def load_schedule(self, year):
+        if self.loading_session:
+            return
+        self.loading_session = True
+        self.schedule_tree.clear()
+        # hide sessions panel while loading / when nothing selected
+        try:
+            self.session_panel.hide()
+        except Exception:
+            pass
+        self.worker = FetchScheduleWorker(int(year))
+        self.worker.result.connect(self.populate_schedule)
+        self.worker.error.connect(self.show_error)
+        self.worker.start()
+    def populate_schedule(self, events):
+        for event in events:
+            # Ensure all columns are strings (QTreeWidgetItem expects text)
+            round_str = str(event.get("round_number", ""))
+            name = str(event.get("event_name", ""))
+            country = str(event.get("country", ""))
+            date = str(event.get("date", ""))
+
+            event_item = QTreeWidgetItem([round_str, name, country, date])
+            event_item.setData(0, Qt.UserRole, event)
+            self.schedule_tree.addTopLevelItem(event_item)
+
+        # Make sure the round column is wide enough to be visible
+        try:
+            self.schedule_tree.resizeColumnToContents(0)
+            self.schedule_tree.resizeColumnToContents(1)
+        except Exception:
+            pass
+
+        self.loading_session = False
+
+    def on_race_clicked(self, item, column):
+        ev = item.data(0, Qt.UserRole)
+        # ensure the sessions panel is visible when a race is selected
+        try:
+            self.session_panel.show()
+        except Exception:
+            pass
+        # determine sessions to show
+        ev_type = (ev.get('type') or '').lower()
+        sessions = ["Qualifying", "Race"]
+        if 'sprint' in ev_type:
+            sessions.insert(0, "Sprint Qualifying")
+            # show sprint-related session
+            sessions.insert(2, "Sprint")
+
+        # clear existing session widgets
+        for i in reversed(range(self.session_list_layout.count())):
+            w = self.session_list_layout.itemAt(i).widget()
+            if w:
+                w.setParent(None)
+
+        # add buttons for each session (launch playback in separate process)
+        for s in sessions:
+            btn = QPushButton(s)
+            btn.clicked.connect(lambda _, sname=s, e=ev: self._on_session_button_clicked(e, sname))
+            self.session_list_layout.addWidget(btn)
+
+    def _on_session_button_clicked(self, ev, session_label):
+        """Launch main.py in a separate process to run the selected session.
+
+        Uses the same CLI flags that `main.py` understands: `--qualifying`,
+        `--sprint-qualifying`, `--sprint`. Runs the command detached so the
+        Qt UI remains responsive.
+        """
+        try:
+            year = int(self.year_combo.currentText())
+        except Exception:
+            year = None
+
+        try:
+            round_no = int(ev.get("round_number"))
+        except Exception:
+            round_no = None
+
+        # map button labels to CLI flags
+        flag = None
+        if session_label == "Qualifying":
+            flag = "--qualifying"
+        elif session_label == "Sprint Qualifying":
+            flag = "--sprint-qualifying"
+        elif session_label == "Sprint":
+            flag = "--sprint"
+
+        main_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'main.py'))
+        cmd = [sys.executable, main_path]
+        if year is not None:
+            cmd += ["--year", str(year)]
+        if round_no is not None:
+            cmd += ["--round", str(round_no)]
+        if flag:
+            cmd.append(flag)
+
+        # Show a modal loading dialog and load the session in a background thread.
+        dlg = QProgressDialog("Loading session data...", None, 0, 0, self)
+        dlg.setWindowTitle("Loading")
+        dlg.setWindowModality(Qt.ApplicationModal)
+        dlg.setCancelButton(None)
+        dlg.setMinimumDuration(0)
+        dlg.setRange(0, 0)
+        dlg.show()
+        QApplication.processEvents()
+
+        # Map label -> fastf1 session type code
+        session_code = 'R'
+        if session_label == "Qualifying":
+            session_code = 'Q'
+        elif session_label == "Sprint Qualifying":
+            session_code = 'SQ'
+        elif session_label == "Sprint":
+            session_code = 'S'
+
+        class FetchSessionWorker(QThread):
+            result = Signal(object)
+            error = Signal(str)
+
+            def __init__(self, year, round_no, session_type, parent=None):
+                super().__init__(parent)
+                self.year = year
+                self.round_no = round_no
+                self.session_type = session_type
+
+            def run(self):
+                try:
+                    try:
+                        from src.f1_data import enable_cache
+                        enable_cache()
+                    except Exception:
+                        pass
+                    sess = load_session(self.year, self.round_no, self.session_type)
+                    self.result.emit(sess)
+                except Exception as e:
+                    self.error.emit(str(e))
+
+        def _on_loaded(session_obj):
+            # create a unique ready-file path and pass it to the child
+            ready_path = os.path.join(tempfile.gettempdir(), f"f1_ready_{uuid.uuid4().hex}")
+            cmd_with_ready = list(cmd) + ["--ready-file", ready_path]
+
+            try:
+                proc = subprocess.Popen(cmd_with_ready)
+            except Exception as exc:
+                try:
+                    dlg.close()
+                except Exception:
+                    pass
+                QMessageBox.critical(self, "Playback error", f"Failed to start playback:\n{exc}")
+                return
+
+            # Poll for ready file or child exit
+            timer = QTimer(self)
+
+            def _check_ready():
+                try:
+                    if os.path.exists(ready_path):
+                        try:
+                            dlg.close()
+                        except Exception:
+                            pass
+                        timer.stop()
+                        try:
+                            os.remove(ready_path)
+                        except Exception:
+                            pass
+                        return
+                    # if process exited early, show error
+                    if proc.poll() is not None:
+                        try:
+                            dlg.close()
+                        except Exception:
+                            pass
+                        timer.stop()
+                        QMessageBox.critical(self, "Playback error", "Playback process exited before signaling readiness")
+                except Exception:
+                    # ignore transient file-system errors
+                    pass
+
+            timer.timeout.connect(_check_ready)
+            timer.start(200)
+            # keep references
+            self._play_proc = proc
+            self._ready_timer = timer
+
+        def _on_error(msg):
+            try:
+                dlg.close()
+            except Exception:
+                pass
+            QMessageBox.critical(self, "Load error", f"Failed to load session data:\n{msg}")
+
+        worker = FetchSessionWorker(year, round_no, session_code)
+        worker.result.connect(_on_loaded)
+        worker.error.connect(_on_error)
+        # Keep a reference so it doesn't get GC'd
+        self._session_worker = worker
+        worker.start()
+    def show_error(self, message):
+        QMessageBox.critical(self, "Error", f"Failed to load schedule: {message}")
+        self.loading_session = False
+        

--- a/src/interfaces/qualifying.py
+++ b/src/interfaces/qualifying.py
@@ -1002,6 +1002,13 @@ class QualifyingReplay(arcade.Window):
             if self.frame_index >= self.n_frames - 1:
                 self.paused = True
 
-def run_qualifying_replay(session, data, title="Qualifying Results"):
+def run_qualifying_replay(session, data, title="Qualifying Results", ready_file=None):
     window = QualifyingReplay(session=session, data=data, title=title)
+    # Signal readiness to parent process (if requested) after window created
+    if ready_file:
+        try:
+            with open(ready_file, 'w') as f:
+                f.write('ready')
+        except Exception:
+            pass
     arcade.run()


### PR DESCRIPTION
### Summary

This GUI allows users to visually select the race and qualifying sessions that they want to view. 

### Statement on the GUI

There have been a lot of requests for a GUI menu to be added to this project. There have also been a few PRs created by some awesome developers, for which I am so grateful, which contain menu systems to allow users to select the specific race weekend that they want to view in the application.

It's been difficult for me to approach building the menu, as it was something on my list, but also knowing that other developers had tried to build it in multiple frameworks, I didn't know which submission to choose.

Logically, the quickest and easiest option would have been to use the GUI elements inside of the Arcade python package. However, I felt as though the style of building interfaces using this option wasn't what I wanted for the project and I knew that whatever was built would eventually be replaced.

I have also seen a PR raised to build a menu in Electron. It looks fantastic, however my concern here is that Electron also isn't the best option from a technical perspective for building this project and taking it to where it needs to go.

Therefore, I have decided to build the initial version of the GUI menu myself to help kickstart the next evolution of this project.

### The GUI

The GUI is built using PySide6, the official python binding for Qt6, which is a great solution for building native desktop applications.

The interface currently features a dropdown menu for selecting the year, a list of the races that are available to view, and a sidebar for selecting the specific session that you would like to view. The interface will display a loading popup while it loads the telemetry in the background.

<img width="1009" height="737" alt="Screenshot 2025-12-26 at 01 15 09" src="https://github.com/user-attachments/assets/3fc2c7db-5496-40ba-8977-d1fb04f1d5f0" />

 