### PR TITLE
Fix for Replay Speeds Available

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -17,7 +17,7 @@ from src.ui_components import (
 SCREEN_WIDTH = 1280
 SCREEN_HEIGHT = 720
 SCREEN_TITLE = "F1 Race Replay"
-PLAYBACK_SPEEDS = [0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]
+PLAYBACK_SPEEDS = [0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
 
 class F1RaceReplayWindow(arcade.Window):
     def __init__(self, frames, track_statuses, example_lap, drivers, title,

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -1122,7 +1122,7 @@ class RaceControlsComponent(BaseComponent):
     - Forward button (right)
     """
     
-    PLAYBACK_SPEEDS = [0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]
+    PLAYBACK_SPEEDS = [0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
 
     def __init__(self, center_x: int = 100, center_y: int = 60, button_size: int = 40, visible=True):
         self.center_x = center_x


### PR DESCRIPTION
The current implementation for replay speed is to multiply the current speed by 2 when the user wants to increase speed and to divide by 2 when the user wants to decrease speed.  However, if a user were to select the lowest speed (0.1x) then increase speed, the user would not be able to return to the default speed (1.0x). Also, there was no limit to the max speed of the replay, which could possibly introduce stability issues.

This merge request adds list of predetermined speed multipliers that can be chosen when the user increases/decreases the replay speed. It will use minimum speed of 0.1x to maximum speed of 64x.