### PR TITLE
Feat: Add visual Track Map Enhancements (Corners & Sectors)

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,13 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
 
     circuit_rotation = get_circuit_rotation(session)
 
+    # Get circuit info (corners, sectors)
+    circuit_info = None
+    try:
+        circuit_info = session.get_circuit_info()
+    except Exception as e:
+        print(f"Warning: Could not get circuit info: {e}")
+
     # Run the arcade replay
 
     run_arcade_replay(
@@ -84,8 +91,9 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
       title=f"{session.event['EventName']} - {'Sprint' if session_type == 'S' else 'Race'}",
       total_laps=race_telemetry['total_laps'],
       circuit_rotation=circuit_rotation,
-      visible_hud=visible_hud
-      ,ready_file=ready_file
+      visible_hud=visible_hud,
+      ready_file=ready_file,
+      circuit_info=circuit_info
     )
 
 if __name__ == "__main__":

--- a/src/arcade_replay.py
+++ b/src/arcade_replay.py
@@ -4,7 +4,7 @@ from src.interfaces.race_replay import F1RaceReplayWindow
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
                       playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None,
-                      visible_hud=True, ready_file=None):
+                      visible_hud=True, ready_file=None, circuit_info=None):
     window = F1RaceReplayWindow(
         frames=frames,
         track_statuses=track_statuses,
@@ -16,6 +16,7 @@ def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
         total_laps=total_laps,
         circuit_rotation=circuit_rotation,
         visible_hud=visible_hud,
+        circuit_info=circuit_info
     )
     # Signal readiness to parent process (if requested) after window created
     if ready_file:


### PR DESCRIPTION
Hey, I noticed the track map was a bit bare, so I added some visual info using the existing FastF1 data.
This PR adds:
- **Turn Numbers:** Shows the corner numbers on the map.
- **Sectors:** draws the marshal sector boundaries so you can see where the splits are.
It just passes the `circuit_info` object from `main.py` down to the window drawing loop. tested it locally and it doesn't seem to affect performance.
Let me know what you think!