### PR TITLE
fix(deps): pin compatible dependencies for python 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-fastf1
-pandas
-matplotlib
-numpy
-arcade
+fastf1>=3.4.0
+pandas>=2.1.0
+matplotlib>=3.7.1
+numpy>=1.26.0
+arcade>=3.0.0
+pillow<12.0.0
 pyglet
 pyside6
 questionary


### PR DESCRIPTION
Pins FastF1, Pandas, and Arcade to versions compatible with Python 3.14 to fix build errors.