### PR TITLE
Add ESC key to close window in qualifying and race replay interfaces

### DIFF
--- a/src/interfaces/qualifying.py
+++ b/src/interfaces/qualifying.py
@@ -668,7 +668,8 @@ class QualifyingReplay(arcade.Window):
                 ("Speed +/- (0.5x, 1x, 2x, 4x)", ("[", "/", "]"), ("arrow-up", "arrow-down")), # text, brackets, icons
                 ("[R]       Restart"),
                 ("[D]       Toggle DRS zones on track map"),
-                ("[C]       Toggle comparison driver telemetry")
+                ("[C]       Toggle comparison driver telemetry"),
+                ("[ESC]    Close Window")
             ]
             for i, lines in enumerate(legend_lines):
                 line = lines[0] if isinstance(lines, tuple) else lines
@@ -795,6 +796,10 @@ class QualifyingReplay(arcade.Window):
         return self.chart_active and self.n_frames > 0 and self.frame_index >= self.n_frames - 1
 
     def on_key_press(self, symbol: int, modifiers: int):
+        # Allow ESC to close window at any time
+        if symbol == arcade.key.ESCAPE:
+            arcade.close_window()
+            return
         # Allow restart (R), comparison toggle (C), and DRS toggle (D) even when lap is complete
         if symbol == arcade.key.R:
             self.frame_index = 0

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -456,6 +456,10 @@ class F1RaceReplayWindow(arcade.Window):
             self.frame_index = float(self.n_frames - 1)
 
     def on_key_press(self, symbol: int, modifiers: int):
+        # Allow ESC to close window at any time
+        if symbol == arcade.key.ESCAPE:
+            arcade.close_window()
+            return
         if symbol == arcade.key.SPACE:
             self.paused = not self.paused
             self.race_controls_comp.flash_button('play_pause')

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -43,6 +43,7 @@ class LegendComponent(BaseComponent):
             ("[R]       Restart"),
             ("[D]       Toggle DRS Zones"),
             ("[B]       Toggle Progress Bar"),
+            ("[ESC]    Close Window"),
         ]
         self._text = arcade.Text("", 0, 0, arcade.color.WHITE, 14)
     


### PR DESCRIPTION
## Problem
When using the qualifying and race replay interfaces, I struggled to find a way to go back to the race selection page. There was no obvious exit mechanism, which made navigation confusing.

## Solution
Added ESC key support to close the window in both interfaces:
- **QualifyingReplay**: Added ESC key handler that closes the window
- **RaceReplay**: Added ESC key handler that closes the window

## Changes
- Added `on_key_press` handler for `arcade.key.ESCAPE` in `src/interfaces/qualifying.py`
- Added `on_key_press` handler for `arcade.key.ESCAPE` in `src/interfaces/race_replay.py`
- Updated `LegendComponent` in `src/ui_components.py` to include ESC key in control instructions
- Updated control legend in `QualifyingReplay` to show ESC key option

## Testing
- Tested ESC key functionality in qualifying interface
- Tested ESC key functionality in race replay interface
- Tested ESC key functionality in sprint qualifying interface 
- Tested ESC key functionality in race qualifying interface
- Verified control legends display correctly in all above interfaces
<img width="2940" height="1710" alt="image" src="https://github.com/user-attachments/assets/509d7d39-dfa3-4ac2-a210-3fee70dca753" />
<img width="2932" height="1714" alt="image" src="https://github.com/user-attachments/assets/76f08645-808b-46df-aaf2-45c21ed23d1a" />
<img width="2936" height="1684" alt="image" src="https://github.com/user-attachments/assets/5e4811fe-adc0-4a14-86a3-062e83b1035e" />
<img width="2934" height="1694" alt="image" src="https://github.com/user-attachments/assets/54c07065-6739-489b-a868-fed6916db930" />

