### PR TITLE
Fix progress bar lap label misalignment

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -766,6 +766,9 @@ class RaceProgressBarComponent(BaseComponent):
         self._events: List[dict] = []
         self._total_frames: int = 0
         self._total_laps: int = 0
+
+        self._frame_denominator: int = max(1, self._total_frames - 1)
+        self._lap_start_frames: List[int] = []
         self._bar_left: float = 0
         self._bar_width: float = 0
         
@@ -785,9 +788,32 @@ class RaceProgressBarComponent(BaseComponent):
         - total_laps: Total number of laps in the race
         - events: List of event dictionaries with keys
         """
-        self._total_frames = max(1, total_frames)
-        self._total_laps = total_laps or 1
-        self._events = sorted(events, key=lambda e: e.get("frame", 0))
+        self._total_frames = max(1, int(total_frames))
+        self._frame_denominator = max(1, self._total_frames - 1)
+        self._total_laps = max(1, int(total_laps or 1))
+        self._events = sorted(events or [], key=lambda e: int(e.get("frame", 0)))
+
+        lap_map = {}
+        for e in self._events:
+            lap = e.get("lap")
+            if lap is None:
+                continue
+            try:
+                lap_i = int(lap)
+            except Exception:
+                continue
+            # prefer the earliest frame for a given lap
+            frame = int(e.get("frame", 0))
+            if lap_i not in lap_map or frame < lap_map[lap_i]:
+                lap_map[lap_i] = frame
+
+        self._lap_start_frames = []
+        for lap in range(1, self._total_laps + 1):
+            if lap in lap_map:
+                self._lap_start_frames.append(max(0, min(lap_map[lap], self._frame_denominator)))
+            else:
+                est = int(((lap - 1) / float(self._total_laps)) * self._frame_denominator)
+                self._lap_start_frames.append(max(0, min(est, self._frame_denominator)))
     
     @property
     def visible(self) -> bool:
@@ -822,14 +848,14 @@ class RaceProgressBarComponent(BaseComponent):
             frame: Frame number to convert
             clamp: Whether to clamp frame to valid range [0, total_frames]
         """
-        if self._total_frames <= 0:
+        if self._frame_denominator <= 0:
             return self._bar_left
-        
-        # here we use Clamp frame to valid range to prevent rendering outside bar bounds
+
+        # Clamp frame to valid range to prevent rendering outside bar bounds
         if clamp:
-            frame = max(0, min(frame, self._total_frames))
-        
-        progress = frame / self._total_frames
+            frame = max(0, min(frame, self._frame_denominator))
+
+        progress = float(frame) / float(self._frame_denominator)
         return self._bar_left + (progress * self._bar_width)
     
     def _x_to_frame(self, x: float) -> int:
@@ -837,7 +863,7 @@ class RaceProgressBarComponent(BaseComponent):
         if self._bar_width <= 0:
             return 0
         progress = (x - self._bar_left) / self._bar_width
-        return int(progress * self._total_frames)
+        return int(progress * self._frame_denominator)
         
     def on_resize(self, window):
         self._calculate_bar_dimensions(window)
@@ -866,7 +892,7 @@ class RaceProgressBarComponent(BaseComponent):
         
         # 2. Draw progress fill
         if self._total_frames > 0:
-            progress_ratio = min(1.0, current_frame / self._total_frames)
+            progress_ratio = min(1.0, float(current_frame) / float(self._frame_denominator))
             progress_width = progress_ratio * self._bar_width
             if progress_width > 0:
                 progress_rect = arcade.XYWH(
@@ -878,20 +904,19 @@ class RaceProgressBarComponent(BaseComponent):
                 arcade.draw_rect_filled(progress_rect, self.COLORS["progress_fill"])
         
         # 3. Draw lap markers (vertical lines)
-        if self._total_laps > 1:
+        if self._total_laps > 1 and self._lap_start_frames:
             for lap in range(1, self._total_laps + 1):
-                # Approximate frame for lap transition
-                lap_frame = int((lap / self._total_laps) * self._total_frames)
+                lap_frame = self._lap_start_frames[lap - 1]
                 lap_x = self._frame_to_x(lap_frame)
-                
+
                 # Draw subtle vertical line
                 arcade.draw_line(
                     lap_x, self.bottom + 2,
                     lap_x, self.bottom + self.height - 2,
                     self.COLORS["lap_marker"], 1
                 )
-                
-                # Draw lap number below for major laps (every 5 laps or first/last)
+
+                # Draw lap number below for major laps (first/last/every 10)
                 if lap == 1 or lap == self._total_laps or lap % 10 == 0:
                     arcade.Text(
                         str(lap),
@@ -958,9 +983,8 @@ class RaceProgressBarComponent(BaseComponent):
     def _draw_flag_segment(self, event: dict, color: tuple):
         start_frame = event.get("frame", 0)
         end_frame = event.get("end_frame", start_frame + 100)  # default duration
-        
-        clamped_start = max(0, min(start_frame, self._total_frames))
-        clamped_end = max(0, min(end_frame, self._total_frames))
+        clamped_start = max(0, min(int(start_frame), self._frame_denominator))
+        clamped_end = max(0, min(int(end_frame), self._frame_denominator))
         
         if clamped_start >= clamped_end:
             # after clamping, if start >= end, the segment is fully outside the
@@ -1090,8 +1114,9 @@ class RaceProgressBarComponent(BaseComponent):
             
             for event in self._events:
                 event_frame = event.get("frame", 0)
-                dist = abs(event_frame - mouse_frame)
-                if dist < min_dist and dist < self._total_frames * 0.02:  # Within 2% of timeline
+                dist = abs(int(event_frame) - mouse_frame)
+                # Within 2% of the timeline
+                if dist < min_dist and dist < self._frame_denominator * 0.02:
                     min_dist = dist
                     nearest_event = event
                     
@@ -1110,7 +1135,7 @@ class RaceProgressBarComponent(BaseComponent):
             # Seek to clicked position
             target_frame = self._x_to_frame(x)
             if hasattr(window, 'frame_index'):
-                window.frame_index = float(max(0, min(target_frame, self._total_frames - 1)))
+                window.frame_index = float(max(0, min(int(target_frame), self._frame_denominator)))
             return True
         return False
 


### PR DESCRIPTION
Fixes an issue where the progress bar playhead and lap labels were misaligned (e.g. lap 21 previewed while the bar appeared closer to lap 23–24). #157.

Potential Cause:
- Progress normalization used ```frame / total_frames```, which treated the timeline as length N instead of frame indices 0..N-1, causing a ```scale/offset``` error.
- Lap markers were estimated uniformly rather than being anchored to actual lap start frames from the race data.

Fix:
- I added a consistent frame denominator using ```total_frames - 1```.
- And derived lap marker positions from real lap-start frames when available.