### PR TITLE
Add tire life tracking and display in telemetry and leaderboard

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -46,7 +46,7 @@ class F1RaceReplayWindow(arcade.Window):
         self.finished_drivers = []
         self.left_ui_margin = left_ui_margin
         self.right_ui_margin = right_ui_margin
-        self.toggle_drs_zones = True 
+        self.toggle_drs_zones = True
         # UI components
         leaderboard_x = max(20, self.width - self.right_ui_margin + 12)
         self.leaderboard_comp = LeaderboardComponent(x=leaderboard_x, width=240, visible=visible_hud)
@@ -424,7 +424,21 @@ class F1RaceReplayWindow(arcade.Window):
         for code, pos in frame["drivers"].items():
             color = self.driver_colors.get(code, arcade.color.WHITE)
             progress_m = driver_progress.get(code, float(pos.get("dist", 0.0)))
-            driver_list.append((code, color, pos, progress_m))
+
+            # Tire age comes directly from FastF1 API (includes pre-race usage)
+            # Subtract 1 because TyreLife is the lap being driven, not laps completed
+            tire_life = pos.get("tyre_life", 0)
+            tire_age = max(0, int(tire_life) - 1) if tire_life > 0 else 0
+
+            # Debug: Print first frame tire data
+            if self.frame_index < 1 and code == list(frame["drivers"].keys())[0]:
+                print(f"DEBUG: First driver {code} - tyre_life={tire_life}, tire_age={tire_age}")
+
+            # Add tire_age to position data
+            pos_with_age = pos.copy()
+            pos_with_age['tire_age'] = tire_age
+
+            driver_list.append((code, color, pos_with_age, progress_m))
         driver_list.sort(key=lambda x: x[3], reverse=True)
         self.leaderboard_comp.set_entries(driver_list)
         self.leaderboard_comp.draw(self)

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -296,15 +296,33 @@ class LeaderboardComponent(BaseComponent):
                     alpha=255
                 )
 
+                # Tire age display
+                tire_age = pos.get("tire_age", -1)
+                if tire_age >= 0:
+                    tire_age_text = f"L{tire_age}"
+                    # Position tire age text to the left of the tire icon
+                    tire_age_x = tyre_icon_x - icon_size - 32
+                    tire_age_y = top_y - 4
+                    # Use white color for better visibility
+                    arcade.Text(
+                        tire_age_text,
+                        tire_age_x,
+                        tire_age_y,
+                        arcade.color.WHITE,
+                        13,
+                        anchor_x="right",
+                        anchor_y="top",
+                        bold=True
+                    ).draw()
+
                 # DRS Indicator
                 drs_val = pos.get("drs", 0)
                 # DRS is active if value >= 10
                 is_drs_on = drs_val and int(drs_val) >= 10
                 drs_color = arcade.color.GREEN if is_drs_on else arcade.color.GRAY
-                
-                # Position dot to the left of the tyre icon
-                # tyre_icon_x is the center of the tyre icon
-                drs_dot_x = tyre_icon_x - icon_size - 4 
+
+                # Position dot to the left of the tire age text with proper spacing
+                drs_dot_x = tyre_icon_x - icon_size - 12
                 drs_dot_y = tyre_icon_y
 
                 arcade.draw_circle_filled(drs_dot_x, drs_dot_y, 4, drs_color)


### PR DESCRIPTION
# Tire Life Tracking in Race Replay

## Summary

Adds tire life tracking and display to the race replay, showing tire age for each driver in the leaderboard component. Tire data is now collected from the FastF1 API, processed through the telemetry pipeline, and displayed alongside each driver's tire compound indicator.

## Changes

### Data Collection (`src/f1_data.py`)

- Extract `TyreLife` data from lap telemetry (represents actual tire age in laps)
- Add `tyre_life_all` array to store tire life values per telemetry point
- Include tire life in the resampling process to maintain data consistency across all frames
- Add `tyre_life` field to the frame data structure for each driver

### UI Display (`src/ui_components.py`)

- Display tire age in **`L{age}`** format in the leaderboard (e.g., `L5` for 5 laps on current tires)
- Position tire age text to the left of the tire compound icon
- Calculate tire age as `tyre_life - 1`  
  (`TyreLife` represents the lap being driven, not laps completed)
- Use white, bold text for improved visibility

### Race Replay Integration (`src/interfaces/race_replay.py`)

- Process tire life data from frame data
- Calculate tire age for each driver at each frame
- Pass tire age information to the leaderboard component

## Visual Example

The leaderboard now displays:

```
[Position] [Driver Code] L5 [DRS DOT] [Tire Icon] [Gap]
```

Where `L5` indicates the driver has completed 5 laps on their current set of tires.

## Technical Notes

- Tire age calculation correctly handles pre-race tire usage (data sourced directly from the FastF1 API)
- Defaults to `0` laps if tire life data is unavailable
- Debug logging added for the first frame to verify data correctness