### PR TITLE
Add sector-based delta widget to Qualifying GUI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastf1
 pandas
 matplotlib
 numpy
+pandas
 arcade
 pyglet
 pyside6


### PR DESCRIPTION
## Qualifying GUI: Distance-Aligned Delta & Sector Delta Widget

### Summary
Improves qualifying lap comparison accuracy and visualization by switching delta calculations to **distance-aligned telemetry**, making comparisons **session-aware (Q1/Q2/Q3)**, and adding a new **sector-based delta widget** styled after F1 broadcast timing.

---

### What Changed

#### Distance-Aligned Delta Calculation
- Live delta is now computed by aligning drivers at the same lap distance (`rel_dist` / `dist`) rather than frame index.
- Reference lap time is linearly interpolated at the matching distance point.
- Delta text is cached and recomputed every 5 frames for smoother playback.

#### Session-Aware Comparison Logic
- Comparison telemetry always comes from the **same qualifying segment** as the selected lap.
  - Example: a Q2 lap compares against the fastest Q2 lap, not Q3.
- UI labels consistently show:
  - `Comparison driver: <CODE> (<Qx>)`
  - Official lap time for the comparison lap.

#### Sector Boundaries & Timing
- Sector boundaries are derived from relative distance:
  - Preferred: FastF1 `Sector1Time` + `Sector2Time`
  - Fallback: equal thirds if sector timing data is unavailable
- Sector times are computed using distance-aligned interpolation for both:
  - Selected lap
  - Comparison lap
- Per-sector deltas and cumulative split times are stored at sector boundaries.

#### Sector Bests (Global & Personal)
- Built caches from `session.laps`:
  - Global best sector times across all drivers
  - Per-driver personal best sector times
- Sector splits and comparisons respect qualifying segment (Q1/Q2/Q3).

#### Sector Delta Table UI
- Replaced the simple S1/S2/S3 row with a **3×3 table**:
  - Rows: Comparison (fastest) / Selected / Delta
  - Columns: Label | S1 | S2 | S3
- Behavior:
  - Only the active sector animates.
  - Completed sectors freeze their times.
  - Upcoming sectors display `--` until active.

#### F1-Style Sector Coloring
Applied per-sector coloring:
- **Purple (`#9B4DFF`)** — overall session best
- **Green (`#1AFF6B`)** — driver personal best
- **Yellow (`#FFDD33`)** — other valid sector times

Visualization uses a **colored underline beneath each sector time** for clarity with minimal UI clutter.

#### Delta Formatting
- Live delta and sector deltas are displayed in **seconds** (e.g. `+0.123s`) instead of lap-style formatting.

---

### Notes / Future Improvements
- If official sector timing data is consistently available via FastF1, fallback sector logic can be simplified.
- The sector widget design can be extended to support multi-driver comparisons.


### Screenshot
<img width="2559" height="1382" alt="Screenshot 2026-01-14 112943" src="https://github.com/user-attachments/assets/890d52ce-d6ff-4c67-b7d3-b198c1497064" />
