### PR TITLE
Fix: f-string bug in Python 3.11

### DIFF
--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -758,7 +758,7 @@ def _process_quali_driver(args):
         except ValueError:
             driver_telemetry_data[segment] = {"frames": [], "track_statuses": []}
 
-    print(f"Finished processing qualifying telemetry for driver: {driver_code}, {session.get_driver(driver_code)["FullName"]},")
+    print(f"Finished processing qualifying telemetry for driver: {driver_code}, {session.get_driver(driver_code)['FullName']},")
     return {
         "driver_code": driver_code,
         "driver_full_name": session.get_driver(driver_code)["FullName"],


### PR DESCRIPTION
# Problem
A ``SyntaxError`` occurs in Python 3.11 due to a f-string that contains unescaped double quotes. This line is valid in Python 3.12+, but crashes in 3.11.

# Solution
To maintain Python 3.11 compatibility, the f-string should use single quotes inside the braces.
If the project prefers to use double quotes in f-strings, the minimum Python version should be updated to 3.12+ in the README.

This PR applies a single quote fix to make the code run on 3.11. 
An alternative solution would be to escape the double quotes inside the f-string, e.g. ``{session.get_driver(driver_code)\"FullName\"]}``, which also works in 3.11.
