### PR TITLE
Add session info banner component

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,6 +71,17 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
     # Get circuit rotation
 
     circuit_rotation = get_circuit_rotation(session)
+    
+    # Prepare session info for display banner
+    session_info = {
+        'event_name': session.event.get('EventName', ''),
+        'circuit_name': session.event.get('Location', ''),  # Circuit location/name
+        'country': session.event.get('Country', ''),
+        'year': year,
+        'round': round_number,
+        'date': session.event.get('EventDate', '').strftime('%B %d, %Y') if session.event.get('EventDate') else '',
+        'total_laps': race_telemetry['total_laps']
+    }
 
     # Run the arcade replay
 
@@ -84,8 +95,9 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
       title=f"{session.event['EventName']} - {'Sprint' if session_type == 'S' else 'Race'}",
       total_laps=race_telemetry['total_laps'],
       circuit_rotation=circuit_rotation,
-      visible_hud=visible_hud
-      ,ready_file=ready_file
+      visible_hud=visible_hud,
+      ready_file=ready_file,
+      session_info=session_info
     )
 
 if __name__ == "__main__":

--- a/src/arcade_replay.py
+++ b/src/arcade_replay.py
@@ -4,7 +4,7 @@ from src.interfaces.race_replay import F1RaceReplayWindow
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
                       playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None,
-                      visible_hud=True, ready_file=None):
+                      visible_hud=True, ready_file=None, session_info=None):
     window = F1RaceReplayWindow(
         frames=frames,
         track_statuses=track_statuses,
@@ -16,6 +16,7 @@ def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
         total_laps=total_laps,
         circuit_rotation=circuit_rotation,
         visible_hud=visible_hud,
+        session_info=session_info,
     )
     # Signal readiness to parent process (if requested) after window created
     if ready_file:

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -10,6 +10,7 @@ from src.ui_components import (
     RaceProgressBarComponent,
     RaceControlsComponent,
     ControlsPopupComponent,
+    SessionInfoComponent,
     extract_race_events,
     build_track_from_example_lap,
     draw_finish_line
@@ -24,7 +25,8 @@ PLAYBACK_SPEEDS = [0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 2
 class F1RaceReplayWindow(arcade.Window):
     def __init__(self, frames, track_statuses, example_lap, drivers, title,
                  playback_speed=1.0, driver_colors=None, circuit_rotation=0.0,
-                 left_ui_margin=340, right_ui_margin=260, total_laps=None, visible_hud=True):
+                 left_ui_margin=340, right_ui_margin=260, total_laps=None, visible_hud=True,
+                 session_info=None):
         # Set resizable to True so the user can adjust mid-sim
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, title, resizable=True)
         self.maximize()
@@ -77,6 +79,19 @@ class F1RaceReplayWindow(arcade.Window):
             center_y=100,
             visible = visible_hud
         )
+        
+        # Session info banner component
+        self.session_info_comp = SessionInfoComponent(visible=visible_hud)
+        if session_info:
+            self.session_info_comp.set_info(
+                event_name=session_info.get('event_name', ''),
+                circuit_name=session_info.get('circuit_name', ''),
+                country=session_info.get('country', ''),
+                year=session_info.get('year'),
+                round_num=session_info.get('round'),
+                date=session_info.get('date', ''),
+                total_laps=total_laps
+            )
 
         self.is_rewinding = False
         self.is_forwarding = False
@@ -447,6 +462,9 @@ class F1RaceReplayWindow(arcade.Window):
         
         # Race playback control buttons
         self.race_controls_comp.draw(self)
+        
+        # Session info banner (top of screen)
+        self.session_info_comp.draw(self)
 
         # Draw Controls popup box
         self.controls_popup_comp.draw(self)
@@ -535,6 +553,8 @@ class F1RaceReplayWindow(arcade.Window):
                 self.controls_popup_comp.show_over(left_pos, top_pos)
         elif symbol == arcade.key.B:
             self.progress_bar_comp.toggle_visibility() # toggle progress bar visibility
+        elif symbol == arcade.key.I:
+            self.session_info_comp.toggle_visibility() # toggle session info banner
 
     def on_key_release(self, symbol: int, modifiers: int):
         if symbol == arcade.key.RIGHT:

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -865,6 +865,100 @@ class ControlsPopupComponent(BaseComponent):
         return True
 
 
+class SessionInfoComponent(BaseComponent):
+    """
+    Displays session information banner at the top-center of the screen.
+    Shows: Circuit name, Country, Event name, Year, Round, Date, Total laps
+    """
+    def __init__(self, visible=True):
+        self.visible = visible
+        self.session_info = {}
+        self._text = arcade.Text("", 0, 0, arcade.color.WHITE, 14)
+        
+    def set_info(self, event_name: str = "", circuit_name: str = "", country: str = "",
+                 year: int = None, round_num: int = None, date: str = "", total_laps: int = None):
+        """Set session information to display"""
+        self.session_info = {
+            'event_name': event_name,
+            'circuit_name': circuit_name,
+            'country': country,
+            'year': year,
+            'round': round_num,
+            'date': date,
+            'total_laps': total_laps
+        }
+    
+    def toggle_visibility(self) -> bool:
+        """Toggle visibility of session info banner"""
+        self.visible = not self.visible
+        return self.visible
+    
+    def draw(self, window):
+        if not self.visible or not self.session_info:
+            return
+        
+        # Banner dimensions
+        banner_height = 60
+        banner_width = min(900, window.width - 40)
+        center_x = window.width / 2
+        top_y = window.height - 10
+        bottom_y = top_y - banner_height
+        
+        # Draw semi-transparent background
+        rect = arcade.XYWH(center_x, top_y - banner_height/2, banner_width, banner_height)
+        arcade.draw_rect_filled(rect, (20, 20, 20, 220))
+        arcade.draw_rect_outline(rect, arcade.color.GRAY, 2)
+        
+        # Get info
+        event = self.session_info.get('event_name', '')
+        circuit = self.session_info.get('circuit_name', '')
+        country = self.session_info.get('country', '')
+        year = self.session_info.get('year', '')
+        round_num = self.session_info.get('round', '')
+        date = self.session_info.get('date', '')
+        total_laps = self.session_info.get('total_laps', '')
+        
+        # Line 1: Event Name | Circuit | Country
+        line1_parts = []
+        if event:
+            line1_parts.append(f"🏁 {event}")
+        if circuit:
+            line1_parts.append(circuit)
+        if country:
+            line1_parts.append(f"🌍 {country}")
+        
+        line1 = " | ".join(line1_parts)
+        
+        # Line 2: Year Round X | Date | X Laps
+        line2_parts = []
+        if year and round_num:
+            line2_parts.append(f"📅 {year} Round {round_num}")
+        elif year:
+            line2_parts.append(f"📅 {year}")
+        if date:
+            line2_parts.append(date)
+        if total_laps:
+            line2_parts.append(f"{total_laps} Laps")
+        
+        line2 = " | ".join(line2_parts)
+        
+        # Draw text lines
+        self._text.font_size = 16
+        self._text.bold = True
+        self._text.color = arcade.color.WHITE
+        self._text.text = line1
+        self._text.x = center_x
+        self._text.y = top_y - 18
+        self._text.anchor_x = "center"
+        self._text.anchor_y = "center"
+        self._text.draw()
+        
+        self._text.font_size = 13
+        self._text.bold = False
+        self._text.color = arcade.color.LIGHT_GRAY
+        self._text.text = line2
+        self._text.y = top_y - 40
+        self._text.draw()
 
 
 # Feature: race progress bar with event markers


### PR DESCRIPTION
## Session Info Banner Feature

### Description
This PR adds a new **Session Info Banner** component that displays comprehensive race session metadata in a prominent banner at the top-center of the screen.
### Problem Solved
Currently, session information (event name, circuit, date, etc.) is only visible in the window title, which is easy to miss. This feature makes essential session metadata clearly visible during race replay without cluttering the interface.

**Files Changed:**
- [src/ui_components.py](cci:7://file:///Users/sriks/Documents/Projects/f1-race-replay/src/ui_components.py:0:0-0:0) - New [SessionInfoComponent](cci:2://file:///Users/sriks/Documents/Projects/f1-race-replay/src/ui_components.py:867:0-960:25) class (~100 lines)
- [src/interfaces/race_replay.py](cci:7://file:///Users/sriks/Documents/Projects/f1-race-replay/src/interfaces/race_replay.py:0:0-0:0) - Component integration and rendering
- [src/arcade_replay.py](cci:7://file:///Users/sriks/Documents/Projects/f1-race-replay/src/arcade_replay.py:0:0-0:0) - Pass `session_info` parameter
- [main.py](cci:7://file:///Users/sriks/Documents/Projects/f1-race-replay/main.py:0:0-0:0) - Extract session metadata from FastF1 session object


## Technical Details

**Data Sources:**
All information is sourced from the FastF1 `session.event` object:
- Event name, country, location (circuit)
- Date (formatted as "Month DD, YYYY")
- Year and round number from user input
- Total laps from race telemetry

**Design Decisions:**
- **Position:** Top-center to avoid conflicts with existing UI (leaderboard on right, telemetry on left)
- **Size:** Max 900px width, 60px height - compact but readable
- **Colors:** Dark semi-transparent background (rgba 20,20,20,220), white/gray text
- **Layout:** Two-line display for compact presentation

### User Controls
- **[I]** key - Toggle session info banner on/off

### Testing
- Code compiles without errors (`python -m py_compile`)
- Banner displays correctly with all session data
- Toggle functionality works as expected
- Adapts to window width (responsive design)
- Does not obstruct race view or other UI elements
- Gracefully handles missing data fields

### Backwards Compatibility
- No breaking changes
- Optional parameter (`session_info=None`) - works without data
- Existing functionality unchanged

### Contribution Guidelines
Following the [roadmap.md](https://github.com/IAmTomShaw/f1-race-replay/blob/main/roadmap.md) contribution guidelines:
- Focused PR - only session info banner feature
- Clear description with technical details
- Aligns with project goal of improving user experience
- Maintains clean, readable code structure

### Additional Notes
This feature enhances the session information display mentioned in community discussions, providing users with always-visible context about what race they're watching. The design is intentionally minimal to maintain the clean aesthetic of the application while adding significant value.