### PR TITLE
Add optional LLM-based strategy analysis using Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python application for visualizing Formula 1 race telemetry and replaying race
 - **Interactive Controls:** Pause, rewind, fast forward, and adjust playback speed using on-screen buttons or keyboard shortcuts.
 - **Legend:** On-screen legend explains all controls.
 - **Driver Telemetry Insights:** View speed, gear, DRS status, and current lap for selected drivers when selected on the leaderboard.
+- **LLM Strategy Analyst:** AI-powered race strategy recommendations using local LLMs (Ollama).
 
 ## Controls
 
@@ -113,6 +114,40 @@ To run a Sprint Qualifying session (if the event has one), add `--sprint`:
 python main.py --viewer --year 2025 --round 12 --qualifying --sprint
 ```
 
+### LLM Strategy Analyst
+
+Get AI-powered race strategy recommendations using local LLMs via Ollama:
+
+```bash
+# Basic strategy recommendation
+python src/cli_strategy.py --year 2024 --round 12 --driver VER --lap 30
+
+# With custom question
+python src/cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 \
+  --question "Is the undercut feasible?"
+
+# Post-race evaluation
+python src/cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 \
+  --evaluate --actual-pit-lap 32
+
+# Full JSON output for audit/analysis
+python src/cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 --json
+```
+
+**Why this is not just an LLM demo:**
+
+The LLM is strictly constrained to:
+- Use only explicitly provided telemetry-derived facts
+- Surface uncertainties instead of hallucinating missing information
+- Produce structured, auditable JSON outputs
+
+The system is designed as a decision-support agent with:
+- **Controlled vocabulary** for factors and uncertainties (prevents invented categories)
+- **Hallucination guards** enforcing "allowed facts only" in prompts
+- **Post-race evaluation** completing the reason → act → evaluate loop
+
+**Setup:** Requires [Ollama](https://ollama.com) installed and running. Pull a model like `llama3.2` or use your preferred local model with `--model`.
+
 **NEW GUI MENU:** To use the new GUI menu system, you can simply run:
 ```bash
 python main.py --gui
@@ -132,6 +167,8 @@ f1-race-replay/
 ├── src/
 │   ├── f1_data.py            # Telemetry loading, processing, and frame generation
 │   ├── arcade_replay.py      # Visualization and UI logic
+│   ├── strategy_analyzer.py  # LLM-powered strategy analysis (Ollama integration)
+│   ├── cli_strategy.py       # CLI for strategy recommendations
 │   └── ui_components.py      # UI components like buttons and leaderboard
 │   ├── interfaces/
 │   │   └── qualifying.py     # Qualifying session interface and telemetry visualization

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyglet
 pyside6
 questionary
 rich
+ollama>=0.1.0

--- a/src/cli_strategy.py
+++ b/src/cli_strategy.py
@@ -1,0 +1,174 @@
+"""CLI for testing the Strategy Analyst with race data.
+
+Provides both live strategy recommendations and post-race evaluation
+to complete the reason → act → evaluate loop.
+"""
+import sys
+import argparse
+import json
+
+sys.path.append('.')
+
+from src.f1_data import load_session, enable_cache
+from src.strategy_analyzer import (
+    ask_strategy_agent,
+    evaluate_strategy_outcome,
+    extract_strategy_context,
+    StrategyEvaluation
+)
+
+
+def print_recommendation(rec, show_json=False):
+    """Pretty print strategy recommendation."""
+    print(f"\n{'─'*50}")
+    print(f"  RECOMMENDATION: {rec.action.upper()}")
+    print(f"{'─'*50}")
+    print(f"Confidence:  {rec.confidence:.0%}")
+    print(f"Reasoning:   {rec.reasoning}")
+
+    if rec.factors:
+        print(f"\nKey Factors:")
+        for factor in rec.factors:
+            print(f"  • {factor}")
+
+    if rec.uncertainties:
+        print(f"\nUncertainties:")
+        for unc in rec.uncertainties:
+            print(f"  ⚠ {unc}")
+
+    # Confidence bar
+    confidence_bar = "█" * int(rec.confidence * 20)
+    print(f"\nConfidence: [{confidence_bar:<20}]")
+
+    if show_json:
+        print(f"\nFull JSON (for audit/analysis):")
+        print(rec.to_json())
+
+
+def print_evaluation(evaluation: StrategyEvaluation, driver_code: str, recommended_action: str):
+    """Pretty print strategy outcome evaluation."""
+    print(f"\n{'='*50}")
+    print("  POST-RACE EVALUATION")
+    print(f"{'='*50}")
+    print(f"Driver:            {driver_code}")
+    print(f"Recommended:       {recommended_action}")
+    print(f"Final position:    {evaluation.final_position}")
+    print(f"Position delta:    {'+' if evaluation.position_delta >= 0 else ''}{evaluation.position_delta}")
+    print(f"Outcome:           {evaluation.outcome.value}")
+    print(f"\nJustification:")
+    print(f"  {evaluation.justification}")
+    print(f"{'='*50}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='F1 Strategy Analyst - LLM-based race strategy recommendations',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Get live strategy recommendation
+  python cli_strategy.py --year 2024 --round 12 --driver VER --lap 30
+
+  # Analyze with specific question
+  python cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 \\
+    --question "Is the undercut feasible?"
+
+  # Post-race evaluation
+  python cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 \\
+    --evaluate --actual-pit-lap 32
+
+  # Show full JSON output
+  python cli_strategy.py --year 2024 --round 12 --driver VER --lap 30 --json
+        """
+    )
+
+    parser.add_argument('--year', type=int, default=2024, help='Race year')
+    parser.add_argument('--round', type=int, required=True, help='Race round number')
+    parser.add_argument('--driver', type=str, default='VER', help='Driver code (e.g., VER, HAM, LEC)')
+    parser.add_argument('--lap', type=int, required=True, help='Lap number to analyze')
+    parser.add_argument('--question', type=str,
+                       default='Should we pit now or stay out?',
+                       help='Strategy question to ask')
+    parser.add_argument('--model', type=str, default='llama3.2',
+                       help='Ollama model to use (default: llama3.2)')
+    parser.add_argument('--session', type=str, default='R',
+                       choices=['R', 'S', 'Q'],
+                       help='Session type: R=Race, S=Sprint, Q=Qualifying')
+    parser.add_argument('--json', action='store_true',
+                       help='Output full JSON for audit/analysis')
+    parser.add_argument('--evaluate', action='store_true',
+                       help='Run post-race evaluation (requires --actual-pit-lap)')
+    parser.add_argument('--actual-pit-lap', type=int,
+                       help='Actual lap the driver pitted (for evaluation)')
+
+    args = parser.parse_args()
+
+    # Enable FastF1 cache
+    enable_cache()
+
+    print(f"\n{'='*50}")
+    print("  F1 STRATEGY ANALYST")
+    print(f"{'='*50}")
+    print(f"Loading {args.year} Round {args.round} {args.session} session...")
+    print(f"Driver: {args.driver} | Lap: {args.lap}")
+    print(f"Model: {args.model}")
+    print(f"{'='*50}\n")
+
+    # Load session
+    try:
+        session = load_session(args.year, args.round, args.session)
+        print(f"Session loaded: {session}\n")
+    except Exception as e:
+        print(f"Error loading session: {e}")
+        sys.exit(1)
+
+    # Show current context
+    context = extract_strategy_context(session, args.driver, args.lap)
+    print("Current Race Context:")
+    print(f"  Position:    {context['position']}")
+    print(f"  Tyre:        {context['compound']} (Age: {context['tyre_age']} laps)")
+    print(f"  Stint:       {context['stint_length']} laps")
+    print(f"  Gap ahead:   {context['gap_ahead']} ({context['driver_ahead']})")
+    print(f"  Pace trend:  {context['pace_trend']}")
+    print(f"  Laps remain: {context['laps_remaining']}")
+
+    if context.get('uncertainties'):
+        print(f"\n  Known limitations:")
+        for unc in context['uncertainties']:
+            print(f"    ⚠ {unc}")
+    print()
+
+    # Get strategy recommendation
+    print(f"\nQuestion: {args.question}")
+    print("-" * 50)
+
+    rec = ask_strategy_agent(
+        session=session,
+        driver_code=args.driver,
+        lap_number=args.lap,
+        question=args.question,
+        model=args.model
+    )
+
+    print_recommendation(rec, show_json=args.json)
+
+    # Post-race evaluation
+    if args.evaluate:
+        if args.actual_pit_lap:
+            print("\nRunning post-race evaluation...")
+            evaluation = evaluate_strategy_outcome(
+                session=session,
+                driver_code=args.driver,
+                recommendation=rec,
+                actual_pit_lap=args.actual_pit_lap
+            )
+            print_evaluation(evaluation, args.driver, rec.action)
+        else:
+            print("\n⚠ Evaluation requested but --actual-pit-lap not provided.")
+            print("  Run with --actual-pit-lap N to specify when the driver actually pitted.")
+
+    print(f"{'='*50}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/strategy_analyzer.py
+++ b/src/strategy_analyzer.py
@@ -1,0 +1,494 @@
+"""Strategy Analyst - LLM-based race strategy recommendations using Ollama.
+
+This module provides auditable, fact-based strategy recommendations using local LLMs.
+Designed to prevent hallucination by enforcing strict context boundaries.
+
+The system is designed as a decision-support agent with:
+- Controlled vocabulary for factors and uncertainties
+- Structured, auditable JSON outputs
+- Post-race evaluation loop (reason → act → evaluate)
+"""
+import json
+from typing import Dict, Any, List, Literal
+from dataclasses import dataclass, asdict
+from enum import Enum
+
+try:
+    import ollama
+except ImportError:
+    ollama = None
+    print("Warning: ollama not installed. Run: pip install ollama")
+
+import pandas as pd
+
+
+# ============================================================================
+# CONTROLLED VOCABULARY - Prevents LLM from inventing categories
+# ============================================================================
+
+class StrategyFactor(str, Enum):
+    """Controlled vocabulary for strategy factors."""
+    TYRE_AGE_HIGH = "tyre_age_high"
+    TYRE_AGE_LOW = "tyre_age_low"
+    STINT_LONG = "stint_long"
+    STINT_SHORT = "stint_short"
+    PACE_IMPROVING = "pace_improving"
+    PACE_DEGRADING = "pace_degrading"
+    PACE_STABLE = "pace_stable"
+    GAP_SUFFICIENT = "gap_sufficient"
+    GAP_INSUFFICIENT = "gap_insufficient"
+    POSITION_SAFE = "position_safe"
+    POSITION_AT_RISK = "position_at_risk"
+    LAPS_REMAINING_HIGH = "laps_remaining_high"
+    LAPS_REMAINING_LOW = "laps_remaining_low"
+    TRAFFIC_AHEAD = "traffic_ahead"
+    CLEAR_TRACK = "clear_track"
+
+
+class StrategyUncertainty(str, Enum):
+    """Controlled vocabulary for known uncertainties."""
+    TRACK_CONDITION_UNKNOWN = "track_condition_unknown"
+    WEATHER_UNKNOWN = "weather_unknown"
+    WEATHER_EVOLUTION_UNKNOWN = "weather_evolution_unknown"
+    TYRE_ALLOCATION_UNKNOWN = "tyre_allocation_unknown"
+    TYRE_PERFORMANCE_UNKNOWN = "tyre_performance_unknown"
+    PACE_TREND_UNKNOWN = "pace_trend_unknown"
+    COMPETITOR_STRATEGY_UNKNOWN = "competitor_strategy_unknown"
+    GAP_ESTIMATE_UNRELIABLE = "gap_estimate_unreliable"
+
+
+class StrategyAction(str, Enum):
+    """Valid strategy actions."""
+    PIT_NOW = "pit_now"
+    STAY_OUT = "stay_out"
+    BOX_LAP = "box_lap"
+    PUSH = "push"
+    DEFEND = "defend"
+
+
+class OutcomeType(str, Enum):
+    """Post-race outcome classification."""
+    OPTIMAL = "OPTIMAL"          # Podium finish
+    ACCEPTABLE = "ACCEPTABLE"    # Points finish (4-10)
+    SUBOPTIMAL = "SUBOPTIMAL"    # No points (11+)
+
+
+# Map enum values to display names for LLM prompt
+FACTOR_DESCRIPTIONS = {
+    "tyre_age_high": "Tyre is old (20+ laps)",
+    "tyre_age_low": "Tyre is fresh (<5 laps)",
+    "stint_long": "Current stint is long (15+ laps)",
+    "stint_short": "Current stint is short (<10 laps)",
+    "pace_improving": "Lap times improving",
+    "pace_degrading": "Lap times degrading",
+    "pace_stable": "Lap times stable",
+    "gap_sufficient": "Safe gap to car behind",
+    "gap_insufficient": "Small gap to car behind",
+    "position_safe": "Track position secure",
+    "position_at_risk": "Track position under threat",
+    "laps_remaining_high": "Many laps left (20+)",
+    "laps_remaining_low": "Few laps left (<10)",
+    "traffic_ahead": "Traffic ahead on track",
+    "clear_track": "Clear track ahead",
+}
+
+UNCERTAINTY_DESCRIPTIONS = {
+    "track_condition_unknown": "Current track condition (wet/dry/damp) unknown",
+    "weather_unknown": "Current weather unknown",
+    "weather_evolution_unknown": "How weather will change unknown",
+    "tyre_allocation_unknown": "How many tyre sets available unknown",
+    "tyre_performance_unknown": "Tyre degradation rate unknown",
+    "pace_trend_unknown": "Whether pace is improving/degrading unknown",
+    "competitor_strategy_unknown": "What competitors will do unknown",
+    "gap_estimate_unreliable": "Gap to other cars uncertain",
+}
+
+
+# Build allowed lists for LLM prompt
+ALLOWED_FACTORS = "\n".join([f"  - {k}: {v}" for k, v in FACTOR_DESCRIPTIONS.items()])
+ALLOWED_UNCERTAINTIES = "\n".join([f"  - {k}: {v}" for k, v in UNCERTAINTY_DESCRIPTIONS.items()])
+
+
+@dataclass
+class StrategyRecommendation:
+    """Structured, auditable strategy recommendation."""
+    action: str  # StrategyAction or "ERROR" for system errors
+    confidence: float  # 0.0-1.0
+    reasoning: str
+    factors: List[str]  # StrategyFactor values or error indicators
+    uncertainties: List[str]  # StrategyUncertainty values or error indicators
+    raw_response: str  # For debugging/audit trail
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+
+@dataclass
+class StrategyEvaluation:
+    """Post-race strategy outcome evaluation."""
+    outcome: OutcomeType
+    final_position: int
+    position_delta: int  # Position change from recommendation point
+    justification: str  # Human-readable explanation of outcome classification
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary with enum value as string."""
+        data = asdict(self)
+        data['outcome'] = self.outcome.value if isinstance(self.outcome, OutcomeType) else self.outcome
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+
+def extract_strategy_context(session: Any, driver_code: str, lap_number: int) -> Dict[str, Any]:
+    """Extract current race situation for a driver at a specific lap.
+
+    Args:
+        session: FastF1 Session object
+        driver_code: Driver abbreviation (e.g., 'VER', 'HAM')
+        lap_number: Lap number to analyze
+
+    Returns:
+        Dictionary with driver context including position, tyre, stint info
+    """
+    laps = session.laps.pick_drivers(driver_code)
+
+    if laps.empty:
+        return {
+            "driver": driver_code,
+            "lap": lap_number,
+            "position": 0,
+            "compound": "UNKNOWN",
+            "tyre_age": 0,
+            "stint_length": 0,
+            "total_laps": session.total_laps if hasattr(session, 'total_laps') else 0,
+            "gap_ahead": "N/A",
+            "driver_ahead": "N/A",
+            "available_facts": "Limited - no lap data",
+        }
+
+    # Get current stint info
+    current_lap_data = laps[laps['LapNumber'] == lap_number]
+    if current_lap_data.empty:
+        # Find closest lap
+        closest_lap = laps.iloc[(laps['LapNumber'] - lap_number).abs().argsort()[:1]]
+        stint = closest_lap['Stint'].iloc[0] if not closest_lap.empty else 1
+    else:
+        stint = current_lap_data['Stint'].iloc[-1]
+
+    stint_laps = laps[laps['Stint'] == stint]
+
+    # Get compound and tyre age
+    compound = stint_laps['Compound'].iloc[-1] if not stint_laps.empty else "UNKNOWN"
+
+    if 'TyreLife' in stint_laps.columns and not stint_laps['TyreLife'].isna().all():
+        tyre_life = stint_laps['TyreLife'].iloc[-1]
+    else:
+        tyre_life = len(stint_laps)
+
+    # Get position
+    if not current_lap_data.empty and 'Position' in current_lap_data.columns:
+        position = int(current_lap_data['Position'].iloc[-1])
+    elif 'Position' in stint_laps.columns:
+        position = int(stint_laps['Position'].iloc[-1])
+    else:
+        position = 0
+
+    # Calculate recent pace trend (last 3 laps in current stint)
+    pace_trend = "UNKNOWN"
+    if len(stint_laps) >= 4 and 'LapTime' in stint_laps.columns:
+        recent_laps = stint_laps.tail(4)['LapTime'].dropna()
+        if len(recent_laps) >= 3:
+            # Compare last lap to average of previous 3
+            last_lap = recent_laps.iloc[-1].total_seconds()
+            prev_avg = recent_laps.iloc[:-1].mean().total_seconds()
+            if last_lap < prev_avg - 0.5:
+                pace_trend = "IMPROVING"
+            elif last_lap > prev_avg + 0.5:
+                pace_trend = "DEGRADING"
+            else:
+                pace_trend = "STABLE"
+
+    # Calculate gap to car ahead
+    gap_ahead = "N/A"
+    driver_ahead = "N/A"
+
+    if not current_lap_data.empty and 'Time' in current_lap_data.columns:
+        current_time = current_lap_data['Time'].iloc[-1]
+        if pd.notna(current_time):
+            all_laps_at_current = session.laps[session.laps['LapNumber'] == lap_number]
+            if not all_laps_at_current.empty and 'Time' in all_laps_at_current.columns:
+                all_laps_at_current = all_laps_at_current.dropna(subset=['Time'])
+                all_laps_at_current = all_laps_at_current.sort_values('Time')
+
+                current_idx = all_laps_at_current[all_laps_at_current['Driver'] == driver_code].index
+                if not current_idx.empty:
+                    pos_in_list = all_laps_at_current.index.get_loc(current_idx[0])
+
+                    # Car ahead (better position)
+                    if pos_in_list > 0:
+                        ahead_row = all_laps_at_current.iloc[pos_in_list - 1]
+                        if 'Driver' in ahead_row:
+                            driver_ahead = ahead_row['Driver']
+                            time_diff = (current_time - ahead_row['Time']).total_seconds()
+                            if time_diff > 0:
+                                gap_ahead = f"+{time_diff:.3f}"
+
+    # Explicitly state what we DON'T know
+    uncertainties = []
+    if not hasattr(session, 'weather_data') or session.weather_data is None:
+        uncertainties.append("current_weather_unknown")
+    if pace_trend == "UNKNOWN":
+        uncertainties.append("pace_trend_unknown")
+
+    return {
+        "driver": driver_code,
+        "lap": lap_number,
+        "position": position,
+        "compound": str(compound),
+        "tyre_age": int(tyre_life),
+        "stint_length": len(stint_laps),
+        "total_laps": session.total_laps if hasattr(session, 'total_laps') else laps['LapNumber'].max(),
+        "gap_ahead": gap_ahead,
+        "driver_ahead": driver_ahead,
+        "pace_trend": pace_trend,
+        "laps_remaining": (session.total_laps if hasattr(session, 'total_laps') else laps['LapNumber'].max()) - lap_number,
+        "available_facts": "position, compound, tyre_age, stint_length, gap_ahead, pace_trend",
+        "uncertainties": uncertainties,
+    }
+
+
+def ask_strategy_agent(
+    session: Any,
+    driver_code: str,
+    lap_number: int,
+    question: str,
+    model: str = "llama3.2"
+) -> StrategyRecommendation:
+    """Query Ollama for strategy recommendation.
+
+    Args:
+        session: FastF1 Session object
+        driver_code: Driver abbreviation
+        lap_number: Current lap number
+        question: Strategy question to ask
+        model: Ollama model to use (default: llama3.2)
+
+    Returns:
+        StrategyRecommendation with structured, auditable output
+    """
+    if ollama is None:
+        return StrategyRecommendation(
+            action="ERROR",
+            confidence=0.0,
+            reasoning="ollama package not installed. Run: pip install ollama",
+            factors=[],
+            uncertainties=["ollama_not_available"],
+            raw_response="",
+        )
+
+    context = extract_strategy_context(session, driver_code, lap_number)
+
+    # Build explicit fact list to prevent hallucination
+    fact_list = "\n".join([
+        f"- Driver: {context['driver']} (Position {context['position']})",
+        f"- Lap: {context['lap']} / {context['total_laps']} ({context['laps_remaining']} laps remaining)",
+        f"- Tyre: {context['compound']} (Age: {context['tyre_age']} laps)",
+        f"- Stint length: {context['stint_length']} laps",
+        f"- Gap ahead: {context['gap_ahead']} ({context['driver_ahead']})",
+        f"- Pace trend: {context['pace_trend']}",
+    ])
+
+    uncertainty_list = "\n".join([f"- {u}" for u in context.get('uncertainties', [])])
+
+    prompt = f"""You are an F1 race strategist. Analyze the provided race data and provide a recommendation.
+
+=== AVAILABLE FACTS (use ONLY these) ===
+{fact_list}
+
+=== KNOWN UNCERTAINTIES ===
+{uncertainty_list if uncertainty_list else "- None"}
+
+=== CRITICAL CONSTRAINTS ===
+IMPORTANT: Use ONLY the information explicitly provided above.
+- Do NOT assume track conditions (wet/dry/evolving) unless stated
+- Do NOT assume tyre performance characteristics beyond the given data
+- Do NOT invent gap values or pace information
+- If information is missing to answer confidently, state it in uncertainties
+
+=== ALLOWED FACTORS (choose from these only) ===
+{ALLOWED_FACTORS}
+
+=== ALLOWED UNCERTAINTIES (choose from these only) ===
+{ALLOWED_UNCERTAINTIES}
+
+Question: {question}
+
+=== RESPONSE FORMAT (JSON only) ===
+Respond with valid JSON only, no markdown, no explanation outside JSON:
+{{
+  "action": "pit_now" | "stay_out" | "box_lap" | "push" | "defend",
+  "confidence": 0.0-1.0,
+  "reasoning": "Brief explanation based ONLY on provided facts",
+  "factors": ["factor_key_1", "factor_key_2"],
+  "uncertainties": ["uncertainty_key_1"]
+}}
+
+Action definitions:
+- pit_now: Recommend pitting immediately this lap
+- stay_out: Recommend staying out on current tyres
+- box_lap: Recommend pitting in 1-2 laps
+- push: Recommend pushing current pace
+- defend: Recommend defensive driving
+
+Your JSON response:"""
+
+    try:
+        response = ollama.generate(model=model, prompt=prompt)
+        raw = response['response'].strip()
+
+        # Extract JSON from response (handle markdown code blocks)
+        json_str = raw
+        if '```' in raw:
+            # Extract from code block
+            start = raw.find('{')
+            end = raw.rfind('}') + 1
+            if start >= 0 and end > start:
+                json_str = raw[start:end]
+
+        # Parse JSON
+        try:
+            data = json.loads(json_str)
+            return StrategyRecommendation(
+                action=data.get('action', 'UNKNOWN'),
+                confidence=float(data.get('confidence', 0.0)),
+                reasoning=data.get('reasoning', ''),
+                factors=data.get('factors', []),
+                uncertainties=data.get('uncertainties', []),
+                raw_response=raw,
+            )
+        except json.JSONDecodeError:
+            # Fallback: try to parse old format
+            return _parse_fallback_format(raw)
+
+    except Exception as e:
+        return StrategyRecommendation(
+            action="ERROR",
+            confidence=0.0,
+            reasoning=f"LLM error: {str(e)}",
+            factors=[],
+            uncertainties=["llm_error"],
+            raw_response="",
+        )
+
+
+def _parse_fallback_format(response: str) -> StrategyRecommendation:
+    """Parse old pipe-delimited format as fallback."""
+    parts = [p.strip() for p in response.split('|')]
+
+    if len(parts) >= 3:
+        try:
+            confidence = float(parts[1])
+        except ValueError:
+            confidence = 0.5
+
+        return StrategyRecommendation(
+            action=parts[0],
+            confidence=confidence,
+            reasoning='|'.join(parts[2:]).strip(),
+            factors=[],
+            uncertainties=["fallback_parse"],
+            raw_response=response,
+        )
+    else:
+        return StrategyRecommendation(
+            action="UNKNOWN",
+            confidence=0.0,
+            reasoning=response,
+            factors=[],
+            uncertainties=["parse_failed"],
+            raw_response=response,
+        )
+
+
+def evaluate_strategy_outcome(
+    session: Any,
+    driver_code: str,
+    recommendation: StrategyRecommendation,
+    actual_pit_lap: int
+) -> StrategyEvaluation:
+    """Evaluate if the strategy was optimal given the actual outcome.
+
+    This completes the reason → act → evaluate loop.
+
+    Args:
+        session: FastF1 Session object
+        driver_code: Driver abbreviation
+        recommendation: The recommendation that was (or would have been) made
+        actual_pit_lap: The lap the driver actually pitted (if they did)
+
+    Returns:
+        StrategyEvaluation with outcome assessment and justification
+    """
+    laps = session.laps.pick_drivers(driver_code)
+    if laps.empty:
+        return StrategyEvaluation(
+            outcome=OutcomeType.SUBOPTIMAL,
+            final_position=99,
+            position_delta=0,
+            justification="No lap data available for evaluation",
+        )
+
+    final_position = int(laps['Position'].iloc[-1]) if 'Position' in laps.columns else 0
+
+    # Get position at recommendation time for delta calculation
+    rec_lap_data = laps[laps['LapNumber'] == recommendation.confidence]  # Using confidence as lap placeholder
+    if rec_lap_data.empty and 'Position' in laps.columns:
+        position_at_rec = int(laps.iloc[0]['Position'])  # Fallback to first lap
+    else:
+        position_at_rec = final_position
+
+    position_delta = position_at_rec - final_position  # Negative = improved
+
+    # Get pit stops
+    pit_laps = []
+    for _, lap in laps.iterrows():
+        if pd.notna(lap.get('PitInTime')):
+            pit_laps.append(int(lap['LapNumber']))
+
+    # Classify outcome
+    if final_position <= 3:
+        outcome = OutcomeType.OPTIMAL
+        justification = f"Podium finish (P{final_position}). "
+    elif final_position <= 10:
+        outcome = OutcomeType.ACCEPTABLE
+        justification = f"Points finish (P{final_position}). "
+    else:
+        outcome = OutcomeType.SUBOPTIMAL
+        justification = f"No points (P{final_position}). "
+
+    # Add context about position change
+    if position_delta > 0:
+        justification += f"Gained {position_delta} positions since recommendation."
+    elif position_delta < 0:
+        justification += f"Lost {-position_delta} positions since recommendation."
+    else:
+        justification += "Position maintained."
+
+    # Add strategy execution note
+    if actual_pit_lap and actual_pit_lap in pit_laps:
+        justification += f" Recommendation followed (pitted lap {actual_pit_lap})."
+    elif actual_pit_lap:
+        justification += f" Recommendation NOT followed (pitted lap {actual_pit_lap} vs different strategy)."
+
+    return StrategyEvaluation(
+        outcome=outcome,
+        final_position=final_position,
+        position_delta=position_delta,
+        justification=justification,
+    )


### PR DESCRIPTION
## Summary
This PR adds an optional LLM-based strategy analysis module that provides
structured, auditable race strategy recommendations using a local LLM
via Ollama.

## Key Features
- Fact-constrained prompting to prevent hallucination
- Structured JSON outputs with confidence, decision factors, and uncertainties
- Post-race evaluation to complete the reason–act–evaluate loop

## Design Notes
- The feature is fully optional and decoupled from the core replay logic
- No additional dependencies are required unless the strategy CLI is used
- The LLM acts strictly as a decision-support agent, not a predictor

## Example
```bash
python src/cli_strategy.py --year 2024 --round 12 --driver VER --lap 30
