### PR TITLE
feat: Add Comparative Telemetry Overlays feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,32 @@ To run a Sprint Qualifying session (if the event has one), add `--sprint`:
 python main.py --viewer --year 2025 --round 12 --qualifying --sprint
 ```
 
+### Telemetry Comparison Tool
+
+Compare lap telemetry between two drivers or different laps from the same driver. This generates multi-panel charts showing Speed, Throttle/Brake, and Delta Time indexed by track distance.
+
+**Interactive mode** (guided CLI):
+```bash
+python main.py --compare
+```
+
+**Quick mode** (command-line arguments):
+```bash
+# Compare VER lap 10 vs HAM lap 15 in the 2024 Bahrain GP race
+python main.py --compare --year 2024 --round 1 --driver1 VER --lap1 10 --driver2 HAM --lap2 15
+
+# Compare qualifying laps
+python main.py --compare --year 2024 --round 1 --qualifying --driver1 VER --lap1 1 --driver2 LEC --lap2 1
+
+# Save chart to file instead of displaying
+python main.py --compare --year 2024 --round 1 --driver1 VER --lap1 10 --driver2 HAM --lap2 15 --save output.png
+```
+
+The comparison chart includes:
+- **Speed trace**: Overlay of both laps' speed profiles
+- **Throttle/Brake**: Combined input visualization (throttle above, brake below zero line)
+- **Delta Time**: Cumulative time difference showing where time is gained/lost
+
 ## File Structure
 
 ```
@@ -142,14 +168,22 @@ f1-race-replay/
 │   ├── f1_data.py            # Telemetry loading, processing, and frame generation
 │   ├── arcade_replay.py      # Visualization and UI logic
 │   └── ui_components.py      # UI components like buttons and leaderboard
+│   ├── compare/              # Telemetry comparison module
+│   │   ├── __init__.py       # Module exports
+│   │   ├── telemetry_compare.py  # Distance-based interpolation and alignment
+│   │   └── compare_chart.py  # Matplotlib chart generation
 │   ├── interfaces/
 │   │   └── qualifying.py     # Qualifying session interface and telemetry visualization
 │   │   └── race_replay.py    # Race replay interface and telemetry visualization
+│   ├── cli/
+│   │   ├── race_selection.py # CLI for race selection
+│   │   └── telemetry_compare.py  # CLI for telemetry comparison
 │   └── lib/
 │       └── tyres.py          # Type definitions for telemetry data structures
 │       └── time.py           # Time formatting utilities
 └── .fastf1-cache/            # FastF1 cache folder (created automatically upon first run)
 └── computed_data/            # Computed telemetry data (created automatically upon first run)
+└── comparison_charts/        # Saved comparison charts (created when using --save)
 ```
 
 ## Customization

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from src.arcade_replay import run_arcade_replay
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
 from src.cli.race_selection import cli_load
+from src.cli.telemetry_compare import cli_compare, cli_compare_quick
 from src.gui.race_selection import RaceSelectionWindow
 from PySide6.QtWidgets import QApplication
 
@@ -103,9 +104,42 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
 if __name__ == "__main__":
 
   if "--cli" in sys.argv:
-    # Run the CLI
-
+    # Run the CLI race selection
     cli_load()
+    sys.exit(0)
+
+  if "--compare" in sys.argv:
+    # Run the telemetry comparison CLI
+    # Interactive mode: python main.py --compare
+    # Quick mode: python main.py --compare --year 2024 --round 1 --driver1 VER --lap1 10 --driver2 HAM --lap2 15
+    
+    if "--driver1" in sys.argv and "--driver2" in sys.argv:
+      # Quick comparison mode with command-line arguments
+      year = int(sys.argv[sys.argv.index("--year") + 1]) if "--year" in sys.argv else 2024
+      round_number = int(sys.argv[sys.argv.index("--round") + 1]) if "--round" in sys.argv else 1
+      
+      # Session type
+      session_type = 'R'
+      if "--qualifying" in sys.argv:
+        session_type = 'Q'
+      elif "--sprint" in sys.argv:
+        session_type = 'S'
+      elif "--sprint-qualifying" in sys.argv:
+        session_type = 'SQ'
+      
+      driver1 = sys.argv[sys.argv.index("--driver1") + 1]
+      lap1 = int(sys.argv[sys.argv.index("--lap1") + 1])
+      driver2 = sys.argv[sys.argv.index("--driver2") + 1]
+      lap2 = int(sys.argv[sys.argv.index("--lap2") + 1])
+      
+      save_path = None
+      if "--save" in sys.argv:
+        save_path = sys.argv[sys.argv.index("--save") + 1]
+      
+      cli_compare_quick(year, round_number, session_type, driver1, lap1, driver2, lap2, save_path)
+    else:
+      # Interactive comparison mode
+      cli_compare()
     sys.exit(0)
 
   if "--year" in sys.argv:

--- a/src/cli/telemetry_compare.py
+++ b/src/cli/telemetry_compare.py
@@ -1,0 +1,447 @@
+"""
+CLI interface for telemetry comparison feature.
+
+Allows users to select two laps (driver/lap combinations) and generate
+a comparative telemetry chart showing Speed, Throttle/Brake, and Delta Time.
+"""
+
+import sys
+import os
+from typing import Optional
+from questionary import Style, select, Choice, checkbox
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.table import Table
+
+from src.f1_data import (
+    get_race_weekends_by_year,
+    load_session,
+    enable_cache,
+    get_driver_colors,
+)
+from src.compare import (
+    create_telemetry_comparison,
+    show_comparison_chart,
+    extract_lap_telemetry_from_frames,
+)
+from src.lib.time import format_time
+
+
+# CLI styling matching the existing race_selection.py
+STYLE = Style([
+    ("pointer", "fg:#e10600 bold"),
+    ("selected", "noinherit fg:#64eb34 bold"),
+    ("highlighted", "fg:#e10600 bold"),
+    ("answer", "fg:#64eb34 bold")
+])
+
+
+def get_driver_laps(session, driver_code: str):
+    """
+    Get list of available laps for a specific driver.
+    
+    Returns a list of dicts with lap number and lap time.
+    """
+    driver_laps = session.laps.pick_drivers(driver_code)
+    laps_info = []
+    
+    for _, lap in driver_laps.iterrows():
+        lap_num = int(lap['LapNumber'])
+        lap_time = lap.get('LapTime')
+        
+        if lap_time is not None and hasattr(lap_time, 'total_seconds'):
+            lap_time_str = format_time(lap_time.total_seconds())
+        else:
+            lap_time_str = "N/A"
+        
+        laps_info.append({
+            'lap_number': lap_num,
+            'lap_time_str': lap_time_str,
+            'lap_time': lap_time.total_seconds() if lap_time is not None and hasattr(lap_time, 'total_seconds') else None,
+            'compound': str(lap.get('Compound', 'UNKNOWN')),
+        })
+    
+    return sorted(laps_info, key=lambda x: x['lap_number'])
+
+
+def get_lap_telemetry(session, driver_code: str, lap_number: int):
+    """
+    Extract telemetry data for a specific driver's lap.
+    
+    Returns a dict with telemetry arrays.
+    """
+    import numpy as np
+    
+    driver_laps = session.laps.pick_drivers(driver_code)
+    lap = driver_laps[driver_laps['LapNumber'] == lap_number]
+    
+    if lap.empty:
+        raise ValueError(f"Lap {lap_number} not found for driver {driver_code}")
+    
+    lap = lap.iloc[0]
+    telemetry = lap.get_telemetry()
+    
+    if telemetry is None or telemetry.empty:
+        raise ValueError(f"No telemetry data for {driver_code} lap {lap_number}")
+    
+    return {
+        't': telemetry['Time'].dt.total_seconds().to_numpy(),
+        'dist': telemetry['Distance'].to_numpy(),
+        'speed': telemetry['Speed'].to_numpy(),
+        'throttle': telemetry['Throttle'].to_numpy(),
+        'brake': telemetry['Brake'].to_numpy() * 100.0,  # Normalize to 0-100
+        'gear': telemetry['nGear'].to_numpy(),
+        'drs': telemetry['DRS'].to_numpy() if 'DRS' in telemetry.columns else np.zeros(len(telemetry)),
+    }
+
+
+def rgb_to_matplotlib(rgb_tuple):
+    """Convert 0-255 RGB tuple to 0-1 matplotlib format."""
+    return tuple(c / 255.0 for c in rgb_tuple)
+
+
+def cli_compare():
+    """
+    Interactive CLI for telemetry comparison.
+    
+    Guides user through:
+    1. Year selection
+    2. Round selection
+    3. Session type selection
+    4. Driver 1 + Lap selection
+    5. Driver 2 + Lap selection
+    6. Chart generation
+    """
+    console = Console()
+    console.print(Markdown("# F1 Telemetry Comparison 📊"))
+    console.print(Markdown("Compare lap telemetry between two drivers or laps\n"))
+    
+    enable_cache()
+    
+    # === Year Selection ===
+    current_year = 2025
+    years = [str(year) for year in range(current_year, 2018, -1)]  # FastF1 has good data from 2018+
+    year = select("Choose a year", choices=years, qmark="🗓️ ", style=STYLE).ask()
+    if not year:
+        sys.exit(0)
+    year = int(year)
+    
+    # === Round Selection ===
+    with Progress(
+        SpinnerColumn(style="bold red"),
+        TextColumn("[bold]Loading race schedule…"),
+        console=console,
+        transient=True,
+    ) as progress:
+        progress.add_task("load", total=None)
+        weekends = get_race_weekends_by_year(year)
+    
+    rounds = [
+        Choice(title=f"{row['event_name']} ({row['date']})", value=row['round_number'])
+        for row in weekends
+    ]
+    round_number = select("Choose a round", choices=rounds, qmark="🌏 ", style=STYLE).ask()
+    if not round_number:
+        sys.exit(0)
+    
+    # === Session Type Selection ===
+    session_choices = [
+        Choice(title="Race", value="R"),
+        Choice(title="Qualifying", value="Q"),
+    ]
+    # Check if sprint weekend
+    for row in weekends:
+        if row['round_number'] == round_number and 'sprint' in row['type']:
+            session_choices.insert(0, Choice(title="Sprint Qualifying", value="SQ"))
+            session_choices.insert(1, Choice(title="Sprint", value="S"))
+            break
+    
+    session_type = select("Choose a session", choices=session_choices, qmark="🏁 ", style=STYLE).ask()
+    if not session_type:
+        sys.exit(0)
+    
+    # === Load Session ===
+    with Progress(
+        SpinnerColumn(style="bold red"),
+        TextColumn("[bold]Loading session data (this may take a minute)…"),
+        console=console,
+        transient=True,
+    ) as progress:
+        progress.add_task("load", total=None)
+        session = load_session(year, round_number, session_type)
+    
+    # Get driver info
+    drivers = session.drivers
+    driver_codes = {num: session.get_driver(num)["Abbreviation"] for num in drivers}
+    driver_names = {num: session.get_driver(num).get("FullName", driver_codes[num]) for num in drivers}
+    driver_colors = get_driver_colors(session)
+    
+    console.print(f"\n[bold green]Loaded:[/] {session.event['EventName']} - {session_type}\n")
+    
+    # === Driver 1 Selection ===
+    console.print(Markdown("### Select First Lap"))
+    
+    driver1_choices = [
+        Choice(title=f"{driver_codes[num]} - {driver_names[num]}", value=driver_codes[num])
+        for num in drivers
+    ]
+    driver1_code = select("Select Driver 1", choices=driver1_choices, qmark="🏎️ ", style=STYLE).ask()
+    if not driver1_code:
+        sys.exit(0)
+    
+    # Get laps for driver 1
+    with Progress(
+        SpinnerColumn(style="bold red"),
+        TextColumn(f"[bold]Loading laps for {driver1_code}…"),
+        console=console,
+        transient=True,
+    ) as progress:
+        progress.add_task("load", total=None)
+        driver1_laps = get_driver_laps(session, driver1_code)
+    
+    if not driver1_laps:
+        console.print(f"[red]No laps found for {driver1_code}[/]")
+        sys.exit(1)
+    
+    lap1_choices = [
+        Choice(
+            title=f"Lap {lap['lap_number']:2d} | {lap['lap_time_str']} | {lap['compound']}",
+            value=lap['lap_number']
+        )
+        for lap in driver1_laps
+    ]
+    lap1_number = select(f"Select lap for {driver1_code}", choices=lap1_choices, qmark="🔢 ", style=STYLE).ask()
+    if not lap1_number:
+        sys.exit(0)
+    
+    # Get lap time for label
+    lap1_info = next((lap for lap in driver1_laps if lap['lap_number'] == lap1_number), None)
+    lap1_time = lap1_info['lap_time'] if lap1_info else None
+    
+    # === Driver 2 Selection ===
+    console.print(Markdown("\n### Select Second Lap"))
+    
+    comparison_type = select(
+        "Compare against",
+        choices=[
+            Choice(title="Different driver", value="different"),
+            Choice(title="Same driver (different lap)", value="same"),
+        ],
+        qmark="🔄 ",
+        style=STYLE
+    ).ask()
+    if not comparison_type:
+        sys.exit(0)
+    
+    if comparison_type == "different":
+        # Filter out driver 1 from choices
+        driver2_choices = [
+            Choice(title=f"{driver_codes[num]} - {driver_names[num]}", value=driver_codes[num])
+            for num in drivers if driver_codes[num] != driver1_code
+        ]
+        driver2_code = select("Select Driver 2", choices=driver2_choices, qmark="🏎️ ", style=STYLE).ask()
+        if not driver2_code:
+            sys.exit(0)
+    else:
+        driver2_code = driver1_code
+    
+    # Get laps for driver 2
+    with Progress(
+        SpinnerColumn(style="bold red"),
+        TextColumn(f"[bold]Loading laps for {driver2_code}…"),
+        console=console,
+        transient=True,
+    ) as progress:
+        progress.add_task("load", total=None)
+        driver2_laps = get_driver_laps(session, driver2_code)
+    
+    if not driver2_laps:
+        console.print(f"[red]No laps found for {driver2_code}[/]")
+        sys.exit(1)
+    
+    # Filter out lap 1 if same driver
+    if comparison_type == "same":
+        driver2_laps = [lap for lap in driver2_laps if lap['lap_number'] != lap1_number]
+    
+    if not driver2_laps:
+        console.print(f"[red]No other laps available for {driver2_code}[/]")
+        sys.exit(1)
+    
+    lap2_choices = [
+        Choice(
+            title=f"Lap {lap['lap_number']:2d} | {lap['lap_time_str']} | {lap['compound']}",
+            value=lap['lap_number']
+        )
+        for lap in driver2_laps
+    ]
+    lap2_number = select(f"Select lap for {driver2_code}", choices=lap2_choices, qmark="🔢 ", style=STYLE).ask()
+    if not lap2_number:
+        sys.exit(0)
+    
+    # Get lap time for label
+    lap2_info = next((lap for lap in driver2_laps if lap['lap_number'] == lap2_number), None)
+    lap2_time = lap2_info['lap_time'] if lap2_info else None
+    
+    # === Output Options ===
+    output_choice = select(
+        "Output option",
+        choices=[
+            Choice(title="Display chart", value="display"),
+            Choice(title="Save to file", value="save"),
+            Choice(title="Both", value="both"),
+        ],
+        qmark="💾 ",
+        style=STYLE
+    ).ask()
+    if not output_choice:
+        sys.exit(0)
+    
+    # === Generate Comparison ===
+    console.print(Markdown("\n### Generating Telemetry Comparison..."))
+    
+    with Progress(
+        SpinnerColumn(style="bold red"),
+        TextColumn("[bold]Extracting telemetry data…"),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task("extract", total=None)
+        
+        # Extract telemetry for both laps
+        try:
+            telemetry1 = get_lap_telemetry(session, driver1_code, lap1_number)
+            telemetry2 = get_lap_telemetry(session, driver2_code, lap2_number)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/]")
+            sys.exit(1)
+        
+        # Get colors
+        color1 = rgb_to_matplotlib(driver_colors.get(driver1_code, (0, 200, 100)))
+        color2 = rgb_to_matplotlib(driver_colors.get(driver2_code, (200, 50, 50)))
+        
+        # Create comparison
+        label1 = f"{driver1_code} Lap {lap1_number}"
+        label2 = f"{driver2_code} Lap {lap2_number}"
+        
+        comparison = create_telemetry_comparison(
+            telemetry1, telemetry2,
+            label1=label1, label2=label2,
+            color1=color1, color2=color2,
+            lap_time1=lap1_time, lap_time2=lap2_time,
+        )
+    
+    # Generate chart title
+    event_name = session.event['EventName']
+    session_name = {'R': 'Race', 'Q': 'Qualifying', 'S': 'Sprint', 'SQ': 'Sprint Qualifying'}[session_type]
+    chart_title = f"{year} {event_name} - {session_name}\n{label1} vs {label2}"
+    
+    # Display summary
+    console.print("\n")
+    table = Table(title="Comparison Summary", show_header=True)
+    table.add_column("", style="bold")
+    table.add_column(label1, style="green")
+    table.add_column(label2, style="red")
+    
+    time1_str = format_time(lap1_time) if lap1_time else "N/A"
+    time2_str = format_time(lap2_time) if lap2_time else "N/A"
+    table.add_row("Lap Time", time1_str, time2_str)
+    
+    delta = comparison.delta_time[-1] if len(comparison.delta_time) > 0 else 0
+    delta_str = f"{'+' if delta > 0 else ''}{delta:.3f}s"
+    table.add_row("Delta", "Reference", delta_str)
+    
+    console.print(table)
+    console.print("\n")
+    
+    # Save and/or display
+    save_path = None
+    if output_choice in ("save", "both"):
+        # Generate filename
+        safe_event = event_name.replace(" ", "_").replace("/", "-")
+        filename = f"{year}_{safe_event}_{session_type}_{driver1_code}_L{lap1_number}_vs_{driver2_code}_L{lap2_number}.png"
+        save_path = os.path.join("comparison_charts", filename)
+        
+        # Create directory if needed
+        os.makedirs("comparison_charts", exist_ok=True)
+    
+    if output_choice == "save":
+        show_comparison_chart(comparison, title=chart_title, save_path=save_path)
+        console.print(f"[green]Chart saved to:[/] {save_path}")
+    elif output_choice == "display":
+        console.print("[dim]Opening chart window...[/]")
+        show_comparison_chart(comparison, title=chart_title)
+    else:  # both
+        show_comparison_chart(comparison, title=chart_title, save_path=save_path)
+        console.print(f"[green]Chart saved to:[/] {save_path}")
+        console.print("[dim]Opening chart window...[/]")
+        show_comparison_chart(comparison, title=chart_title)
+    
+    console.print("\n[bold green]Done![/]")
+
+
+def cli_compare_quick(
+    year: int,
+    round_number: int,
+    session_type: str,
+    driver1: str,
+    lap1: int,
+    driver2: str,
+    lap2: int,
+    save_path: Optional[str] = None,
+):
+    """
+    Quick comparison function for command-line arguments.
+    
+    Args:
+        year: Season year
+        round_number: Round number
+        session_type: 'R', 'Q', 'S', or 'SQ'
+        driver1: First driver code (e.g., 'VER')
+        lap1: First lap number
+        driver2: Second driver code (e.g., 'HAM')
+        lap2: Second lap number
+        save_path: Optional path to save the chart
+    """
+    console = Console()
+    enable_cache()
+    
+    console.print(f"[bold]Loading {year} Round {round_number} {session_type}...[/]")
+    session = load_session(year, round_number, session_type)
+    
+    console.print(f"[bold]Extracting telemetry for {driver1} L{lap1} vs {driver2} L{lap2}...[/]")
+    
+    telemetry1 = get_lap_telemetry(session, driver1, lap1)
+    telemetry2 = get_lap_telemetry(session, driver2, lap2)
+    
+    driver_colors = get_driver_colors(session)
+    color1 = rgb_to_matplotlib(driver_colors.get(driver1, (0, 200, 100)))
+    color2 = rgb_to_matplotlib(driver_colors.get(driver2, (200, 50, 50)))
+    
+    # Get lap times
+    driver1_laps = get_driver_laps(session, driver1)
+    driver2_laps = get_driver_laps(session, driver2)
+    lap1_info = next((lap for lap in driver1_laps if lap['lap_number'] == lap1), None)
+    lap2_info = next((lap for lap in driver2_laps if lap['lap_number'] == lap2), None)
+    
+    comparison = create_telemetry_comparison(
+        telemetry1, telemetry2,
+        label1=f"{driver1} Lap {lap1}",
+        label2=f"{driver2} Lap {lap2}",
+        color1=color1, color2=color2,
+        lap_time1=lap1_info['lap_time'] if lap1_info else None,
+        lap_time2=lap2_info['lap_time'] if lap2_info else None,
+    )
+    
+    event_name = session.event['EventName']
+    session_name = {'R': 'Race', 'Q': 'Qualifying', 'S': 'Sprint', 'SQ': 'Sprint Qualifying'}[session_type]
+    chart_title = f"{year} {event_name} - {session_name}"
+    
+    show_comparison_chart(comparison, title=chart_title, save_path=save_path)
+    
+    if save_path:
+        console.print(f"[green]Chart saved to:[/] {save_path}")
+
+
+if __name__ == "__main__":
+    cli_compare()

--- a/src/compare/__init__.py
+++ b/src/compare/__init__.py
@@ -1,0 +1,28 @@
+# Comparative Telemetry Module
+# Provides tools for comparing telemetry data between two laps
+
+from .telemetry_compare import (
+    interpolate_telemetry_to_distance,
+    align_telemetry_by_distance,
+    calculate_delta_time,
+    create_telemetry_comparison,
+    extract_lap_telemetry_from_frames,
+    TelemetryComparison,
+)
+from .compare_chart import (
+    create_comparison_chart,
+    show_comparison_chart,
+    create_mini_comparison_chart,
+)
+
+__all__ = [
+    'interpolate_telemetry_to_distance',
+    'align_telemetry_by_distance', 
+    'calculate_delta_time',
+    'create_telemetry_comparison',
+    'extract_lap_telemetry_from_frames',
+    'TelemetryComparison',
+    'create_comparison_chart',
+    'show_comparison_chart',
+    'create_mini_comparison_chart',
+]

--- a/src/compare/compare_chart.py
+++ b/src/compare/compare_chart.py
@@ -1,0 +1,347 @@
+"""
+Matplotlib chart generation for telemetry comparison.
+
+Creates multi-panel charts comparing Speed, Throttle/Brake, and Delta Time
+between two laps, indexed by track distance.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
+from typing import Optional, Tuple, List
+
+from .telemetry_compare import TelemetryComparison
+
+
+# F1-inspired dark theme colors
+BACKGROUND_COLOR = '#1a1a1a'
+GRID_COLOR = '#333333'
+TEXT_COLOR = '#ffffff'
+AXIS_COLOR = '#666666'
+POSITIVE_DELTA_COLOR = '#ff4444'  # Red - lap2 is slower
+NEGATIVE_DELTA_COLOR = '#44ff44'  # Green - lap2 is faster
+
+
+def setup_dark_style():
+    """Configure matplotlib for F1-style dark theme."""
+    plt.rcParams.update({
+        'figure.facecolor': BACKGROUND_COLOR,
+        'axes.facecolor': BACKGROUND_COLOR,
+        'axes.edgecolor': AXIS_COLOR,
+        'axes.labelcolor': TEXT_COLOR,
+        'axes.titlecolor': TEXT_COLOR,
+        'xtick.color': TEXT_COLOR,
+        'ytick.color': TEXT_COLOR,
+        'text.color': TEXT_COLOR,
+        'grid.color': GRID_COLOR,
+        'grid.alpha': 0.5,
+        'legend.facecolor': '#2a2a2a',
+        'legend.edgecolor': AXIS_COLOR,
+        'legend.labelcolor': TEXT_COLOR,
+        'font.family': 'sans-serif',
+        'font.size': 10,
+    })
+
+
+def create_comparison_chart(
+    comparison: TelemetryComparison,
+    title: Optional[str] = None,
+    figsize: Tuple[float, float] = (14, 10),
+    show_gear: bool = False,
+    show_drs: bool = True,
+    drs_zones: Optional[List[dict]] = None,
+) -> Tuple[Figure, List[Axes]]:
+    """
+    Create a multi-panel comparison chart.
+    
+    The chart contains:
+    - Panel 1: Speed comparison (km/h)
+    - Panel 2: Throttle & Brake comparison (stacked)
+    - Panel 3: Delta Time (cumulative time difference)
+    
+    Args:
+        comparison: TelemetryComparison object with aligned data
+        title: Chart title (auto-generated if None)
+        figsize: Figure size (width, height) in inches
+        show_gear: Whether to overlay gear numbers on speed panel
+        show_drs: Whether to highlight DRS activation zones
+        drs_zones: Optional list of DRS zone definitions
+        
+    Returns:
+        Tuple of (Figure, list of Axes)
+    """
+    setup_dark_style()
+    
+    # Create figure with constrained layout for proper spacing
+    fig = plt.figure(figsize=figsize, constrained_layout=True)
+    
+    # Create grid: 3 rows with different heights
+    gs = gridspec.GridSpec(3, 1, figure=fig, height_ratios=[3, 2, 2])
+    
+    ax_speed = fig.add_subplot(gs[0])
+    ax_inputs = fig.add_subplot(gs[1], sharex=ax_speed)
+    ax_delta = fig.add_subplot(gs[2], sharex=ax_speed)
+    
+    axes = [ax_speed, ax_inputs, ax_delta]
+    
+    # Convert distance to km for better readability
+    dist_km = comparison.distance / 1000.0
+    
+    # === Panel 1: Speed ===
+    ax_speed.plot(
+        dist_km, comparison.lap1_speed,
+        color=comparison.lap1_color, linewidth=1.5,
+        label=comparison.lap1_label, alpha=0.9
+    )
+    ax_speed.plot(
+        dist_km, comparison.lap2_speed,
+        color=comparison.lap2_color, linewidth=1.5,
+        label=comparison.lap2_label, alpha=0.9
+    )
+    
+    ax_speed.set_ylabel('Speed (km/h)', fontsize=11, fontweight='bold')
+    ax_speed.legend(loc='upper right', fontsize=9)
+    ax_speed.grid(True, alpha=0.3)
+    ax_speed.set_ylim(bottom=0)
+    
+    # Add DRS zone highlights
+    if show_drs:
+        _add_drs_highlights(ax_speed, comparison, dist_km)
+    
+    # === Panel 2: Throttle & Brake ===
+    # Throttle (positive, going up)
+    ax_inputs.fill_between(
+        dist_km, 0, comparison.lap1_throttle,
+        alpha=0.3, color=comparison.lap1_color, linewidth=0
+    )
+    ax_inputs.fill_between(
+        dist_km, 0, comparison.lap2_throttle,
+        alpha=0.3, color=comparison.lap2_color, linewidth=0
+    )
+    ax_inputs.plot(
+        dist_km, comparison.lap1_throttle,
+        color=comparison.lap1_color, linewidth=1.2, alpha=0.8
+    )
+    ax_inputs.plot(
+        dist_km, comparison.lap2_throttle,
+        color=comparison.lap2_color, linewidth=1.2, alpha=0.8
+    )
+    
+    # Brake (negative, going down) - shown as negative values
+    brake1_neg = -comparison.lap1_brake
+    brake2_neg = -comparison.lap2_brake
+    ax_inputs.fill_between(
+        dist_km, 0, brake1_neg,
+        alpha=0.3, color=comparison.lap1_color, linewidth=0
+    )
+    ax_inputs.fill_between(
+        dist_km, 0, brake2_neg,
+        alpha=0.3, color=comparison.lap2_color, linewidth=0
+    )
+    ax_inputs.plot(
+        dist_km, brake1_neg,
+        color=comparison.lap1_color, linewidth=1.2, alpha=0.8, linestyle='--'
+    )
+    ax_inputs.plot(
+        dist_km, brake2_neg,
+        color=comparison.lap2_color, linewidth=1.2, alpha=0.8, linestyle='--'
+    )
+    
+    ax_inputs.axhline(y=0, color=AXIS_COLOR, linewidth=0.5)
+    ax_inputs.set_ylabel('Throttle / Brake (%)', fontsize=11, fontweight='bold')
+    ax_inputs.set_ylim(-105, 105)
+    ax_inputs.grid(True, alpha=0.3)
+    
+    # Add labels for throttle/brake regions
+    ax_inputs.text(
+        0.02, 0.95, 'THROTTLE ↑', transform=ax_inputs.transAxes,
+        fontsize=8, alpha=0.6, va='top'
+    )
+    ax_inputs.text(
+        0.02, 0.05, 'BRAKE ↓', transform=ax_inputs.transAxes,
+        fontsize=8, alpha=0.6, va='bottom'
+    )
+    
+    # === Panel 3: Delta Time ===
+    delta = comparison.delta_time
+    
+    # Create filled areas for positive/negative delta
+    positive_mask = list(delta >= 0)
+    negative_mask = list(delta < 0)
+    
+    ax_delta.fill_between(
+        dist_km, 0, delta,
+        where=positive_mask,
+        color=POSITIVE_DELTA_COLOR, alpha=0.4,
+        interpolate=True
+    )
+    ax_delta.fill_between(
+        dist_km, 0, delta,
+        where=negative_mask,
+        color=NEGATIVE_DELTA_COLOR, alpha=0.4,
+        interpolate=True
+    )
+    ax_delta.plot(dist_km, delta, color=TEXT_COLOR, linewidth=1.5)
+    
+    ax_delta.axhline(y=0, color=AXIS_COLOR, linewidth=1)
+    ax_delta.set_ylabel('Δ Time (s)', fontsize=11, fontweight='bold')
+    ax_delta.set_xlabel('Distance (km)', fontsize=11, fontweight='bold')
+    ax_delta.grid(True, alpha=0.3)
+    
+    # Add annotations for delta interpretation
+    final_delta = delta[-1] if len(delta) > 0 else 0
+    if final_delta > 0:
+        delta_text = f'{comparison.lap2_label} is {abs(final_delta):.3f}s SLOWER'
+        delta_color = POSITIVE_DELTA_COLOR
+    else:
+        delta_text = f'{comparison.lap2_label} is {abs(final_delta):.3f}s FASTER'
+        delta_color = NEGATIVE_DELTA_COLOR
+    
+    ax_delta.text(
+        0.98, 0.95, delta_text, transform=ax_delta.transAxes,
+        fontsize=10, fontweight='bold', color=delta_color,
+        ha='right', va='top',
+        bbox=dict(boxstyle='round,pad=0.3', facecolor='#2a2a2a', edgecolor=delta_color)
+    )
+    
+    # === Title ===
+    if title is None:
+        title = f"Telemetry Comparison: {comparison.lap1_label} vs {comparison.lap2_label}"
+    
+    # Add lap times to title if available
+    subtitle_parts = []
+    if comparison.lap1_time is not None:
+        mins1 = int(comparison.lap1_time // 60)
+        secs1 = comparison.lap1_time % 60
+        subtitle_parts.append(f"{comparison.lap1_label}: {mins1}:{secs1:06.3f}")
+    if comparison.lap2_time is not None:
+        mins2 = int(comparison.lap2_time // 60)
+        secs2 = comparison.lap2_time % 60
+        subtitle_parts.append(f"{comparison.lap2_label}: {mins2}:{secs2:06.3f}")
+    
+    fig.suptitle(title, fontsize=14, fontweight='bold', y=0.98)
+    if subtitle_parts:
+        ax_speed.set_title(' | '.join(subtitle_parts), fontsize=10, alpha=0.8, pad=10)
+    
+    # Hide x-axis labels for upper panels
+    plt.setp(ax_speed.get_xticklabels(), visible=False)
+    plt.setp(ax_inputs.get_xticklabels(), visible=False)
+    
+    return fig, axes
+
+
+def _add_drs_highlights(
+    ax: Axes,
+    comparison: TelemetryComparison,
+    dist_km: np.ndarray,
+) -> None:
+    """
+    Add semi-transparent DRS zone highlights to a chart panel.
+    
+    Args:
+        ax: Matplotlib axes to add highlights to
+        comparison: TelemetryComparison with DRS data
+        dist_km: Distance array in kilometers
+    """
+    # Find DRS activation regions for lap1
+    drs1_active = comparison.lap1_drs >= 10  # DRS is typically >= 10 when active
+    
+    if np.any(drs1_active):
+        # Find continuous DRS regions
+        drs_changes = np.diff(drs1_active.astype(int))
+        drs_starts = np.where(drs_changes == 1)[0] + 1
+        drs_ends = np.where(drs_changes == -1)[0] + 1
+        
+        # Handle edge cases
+        if drs1_active[0]:
+            drs_starts = np.concatenate([[0], drs_starts])
+        if drs1_active[-1]:
+            drs_ends = np.concatenate([drs_ends, [len(drs1_active)]])
+        
+        # Add vertical spans for DRS zones
+        for start, end in zip(drs_starts, drs_ends):
+            if start < len(dist_km) and end <= len(dist_km):
+                ax.axvspan(
+                    float(dist_km[start]), float(dist_km[min(end, len(dist_km)-1)]),
+                    alpha=0.1, color='#00ff00', zorder=0
+                )
+
+
+def show_comparison_chart(
+    comparison: TelemetryComparison,
+    title: Optional[str] = None,
+    figsize: Tuple[float, float] = (14, 10),
+    save_path: Optional[str] = None,
+    show_gear: bool = False,
+    show_drs: bool = True,
+) -> None:
+    """
+    Create and display (or save) a telemetry comparison chart.
+    
+    Args:
+        comparison: TelemetryComparison object with aligned data
+        title: Chart title (auto-generated if None)
+        figsize: Figure size (width, height) in inches
+        save_path: If provided, save figure to this path instead of showing
+        show_gear: Whether to overlay gear numbers on speed panel
+        show_drs: Whether to highlight DRS activation zones
+    """
+    fig, axes = create_comparison_chart(
+        comparison, title, figsize, show_gear, show_drs
+    )
+    
+    if save_path:
+        fig.savefig(save_path, dpi=150, facecolor=BACKGROUND_COLOR, bbox_inches='tight')
+        print(f"Chart saved to: {save_path}")
+    else:
+        plt.show()
+    
+    plt.close(fig)
+
+
+def create_mini_comparison_chart(
+    comparison: TelemetryComparison,
+    figsize: Tuple[float, float] = (8, 4),
+) -> Tuple[Figure, Axes]:
+    """
+    Create a simplified single-panel speed comparison chart.
+    
+    Useful for embedding in other interfaces or quick comparisons.
+    
+    Args:
+        comparison: TelemetryComparison object with aligned data
+        figsize: Figure size (width, height) in inches
+        
+    Returns:
+        Tuple of (Figure, Axes)
+    """
+    setup_dark_style()
+    
+    fig, ax = plt.subplots(figsize=figsize)
+    
+    dist_km = comparison.distance / 1000.0
+    
+    ax.plot(
+        dist_km, comparison.lap1_speed,
+        color=comparison.lap1_color, linewidth=1.5,
+        label=comparison.lap1_label
+    )
+    ax.plot(
+        dist_km, comparison.lap2_speed,
+        color=comparison.lap2_color, linewidth=1.5,
+        label=comparison.lap2_label
+    )
+    
+    ax.set_xlabel('Distance (km)')
+    ax.set_ylabel('Speed (km/h)')
+    ax.legend(loc='upper right')
+    ax.grid(True, alpha=0.3)
+    ax.set_ylim(bottom=0)
+    
+    final_delta = comparison.delta_time[-1] if len(comparison.delta_time) > 0 else 0
+    delta_sign = '+' if final_delta > 0 else ''
+    ax.set_title(f'Speed Comparison | Δ: {delta_sign}{final_delta:.3f}s')
+    
+    return fig, ax

--- a/src/compare/telemetry_compare.py
+++ b/src/compare/telemetry_compare.py
@@ -1,0 +1,292 @@
+"""
+Telemetry comparison utilities for F1 Race Replay.
+
+This module provides functions to interpolate, align, and compare telemetry data 
+from two different laps (e.g., Driver A vs Driver B, or Lap 1 vs Lap 50).
+"""
+
+import numpy as np
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple, List
+
+
+@dataclass
+class TelemetryComparison:
+    """
+    Container for aligned telemetry data from two laps.
+    
+    Attributes:
+        distance: Common distance array (meters) used as the x-axis index
+        lap1_speed: Speed trace for lap 1 (km/h)
+        lap2_speed: Speed trace for lap 2 (km/h)
+        lap1_throttle: Throttle trace for lap 1 (0-100%)
+        lap2_throttle: Throttle trace for lap 2 (0-100%)
+        lap1_brake: Brake trace for lap 1 (0-100%)
+        lap2_brake: Brake trace for lap 2 (0-100%)
+        lap1_gear: Gear selection for lap 1
+        lap2_gear: Gear selection for lap 2
+        lap1_drs: DRS status for lap 1
+        lap2_drs: DRS status for lap 2
+        delta_time: Cumulative time difference (lap2 - lap1) in seconds
+        lap1_label: Label for lap 1 (e.g., "VER Lap 1")
+        lap2_label: Label for lap 2 (e.g., "HAM Lap 15")
+        lap1_color: Color for lap 1 traces
+        lap2_color: Color for lap 2 traces
+        lap1_time: Total lap time for lap 1 (seconds)
+        lap2_time: Total lap time for lap 2 (seconds)
+    """
+    distance: np.ndarray
+    lap1_speed: np.ndarray
+    lap2_speed: np.ndarray
+    lap1_throttle: np.ndarray
+    lap2_throttle: np.ndarray
+    lap1_brake: np.ndarray
+    lap2_brake: np.ndarray
+    lap1_gear: np.ndarray
+    lap2_gear: np.ndarray
+    lap1_drs: np.ndarray
+    lap2_drs: np.ndarray
+    delta_time: np.ndarray
+    lap1_label: str
+    lap2_label: str
+    lap1_color: Tuple[float, float, float] = (0.0, 0.8, 0.4)   # Green
+    lap2_color: Tuple[float, float, float] = (0.8, 0.2, 0.2)   # Red
+    lap1_time: Optional[float] = None
+    lap2_time: Optional[float] = None
+
+
+def interpolate_telemetry_to_distance(
+    telemetry: Dict,
+    distance_points: np.ndarray,
+) -> Dict[str, np.ndarray]:
+    """
+    Interpolate telemetry data onto a common distance axis.
+    
+    The input telemetry dict must contain:
+      - 'dist': distance array (meters)
+      - 't': time array (seconds)
+      - 'speed': speed array (km/h)
+      - 'throttle': throttle array (0-100)
+      - 'brake': brake array (0-100)
+      - 'gear': gear array (int)
+      - 'drs': DRS status array
+      
+    Args:
+        telemetry: Dictionary containing telemetry arrays
+        distance_points: Target distance array to interpolate onto
+        
+    Returns:
+        Dictionary with interpolated telemetry arrays
+    """
+    # Extract source data
+    src_dist = np.asarray(telemetry['dist'])
+    src_time = np.asarray(telemetry['t'])
+    src_speed = np.asarray(telemetry['speed'])
+    src_throttle = np.asarray(telemetry['throttle'])
+    src_brake = np.asarray(telemetry['brake'])
+    src_gear = np.asarray(telemetry['gear'])
+    src_drs = np.asarray(telemetry.get('drs', np.zeros_like(src_time)))
+    
+    # Sort by distance (ensure monotonically increasing for interp)
+    order = np.argsort(src_dist)
+    src_dist = src_dist[order]
+    src_time = src_time[order]
+    src_speed = src_speed[order]
+    src_throttle = src_throttle[order]
+    src_brake = src_brake[order]
+    src_gear = src_gear[order]
+    src_drs = src_drs[order]
+    
+    # Remove duplicate distance points (keep first occurrence)
+    unique_dist, unique_idx = np.unique(src_dist, return_index=True)
+    src_dist = unique_dist
+    src_time = src_time[unique_idx]
+    src_speed = src_speed[unique_idx]
+    src_throttle = src_throttle[unique_idx]
+    src_brake = src_brake[unique_idx]
+    src_gear = src_gear[unique_idx]
+    src_drs = src_drs[unique_idx]
+    
+    # Clip target distance to source range
+    dist_min = src_dist.min()
+    dist_max = src_dist.max()
+    target_dist = np.clip(distance_points, dist_min, dist_max)
+    
+    # Interpolate continuous values
+    interp_time = np.interp(target_dist, src_dist, src_time)
+    interp_speed = np.interp(target_dist, src_dist, src_speed)
+    interp_throttle = np.interp(target_dist, src_dist, src_throttle)
+    interp_brake = np.interp(target_dist, src_dist, src_brake)
+    
+    # For discrete values (gear, DRS), use nearest-neighbor interpolation
+    idx = np.searchsorted(src_dist, target_dist, side='right') - 1
+    idx = np.clip(idx, 0, len(src_gear) - 1)
+    interp_gear = src_gear[idx]
+    interp_drs = src_drs[idx]
+    
+    return {
+        'dist': target_dist,
+        't': interp_time,
+        'speed': interp_speed,
+        'throttle': interp_throttle,
+        'brake': interp_brake,
+        'gear': interp_gear,
+        'drs': interp_drs,
+    }
+
+
+def align_telemetry_by_distance(
+    telemetry1: Dict,
+    telemetry2: Dict,
+    num_points: int = 1000,
+) -> Tuple[np.ndarray, Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    """
+    Align two telemetry datasets to a common distance axis.
+    
+    Args:
+        telemetry1: First telemetry dataset
+        telemetry2: Second telemetry dataset
+        num_points: Number of distance points for interpolation
+        
+    Returns:
+        Tuple of (common_distance, interpolated_telemetry1, interpolated_telemetry2)
+    """
+    # Find common distance range
+    dist1 = np.asarray(telemetry1['dist'])
+    dist2 = np.asarray(telemetry2['dist'])
+    
+    dist_min = max(dist1.min(), dist2.min())
+    dist_max = min(dist1.max(), dist2.max())
+    
+    # Create common distance axis
+    common_dist = np.linspace(dist_min, dist_max, num_points)
+    
+    # Interpolate both telemetry sets to the common distance axis
+    interp1 = interpolate_telemetry_to_distance(telemetry1, common_dist)
+    interp2 = interpolate_telemetry_to_distance(telemetry2, common_dist)
+    
+    return common_dist, interp1, interp2
+
+
+def calculate_delta_time(
+    distance: np.ndarray,
+    time1: np.ndarray,
+    time2: np.ndarray,
+) -> np.ndarray:
+    """
+    Calculate cumulative time delta between two laps.
+    
+    Positive delta means lap2 is slower (behind lap1).
+    Negative delta means lap2 is faster (ahead of lap1).
+    
+    Args:
+        distance: Common distance array
+        time1: Time array for lap 1 (interpolated to distance)
+        time2: Time array for lap 2 (interpolated to distance)
+        
+    Returns:
+        Array of cumulative time deltas (lap2 - lap1) in seconds
+    """
+    # Delta time at each distance point
+    delta = time2 - time1
+    return delta
+
+
+def extract_lap_telemetry_from_frames(frames: List[Dict]) -> Dict:
+    """
+    Extract telemetry arrays from a list of frame dictionaries.
+    
+    This is useful for converting qualifying or race telemetry frames 
+    into the format expected by the comparison functions.
+    
+    Args:
+        frames: List of frame dictionaries with 't' and 'telemetry' keys
+        
+    Returns:
+        Dictionary with combined telemetry arrays
+    """
+    t_list = []
+    dist_list = []
+    speed_list = []
+    throttle_list = []
+    brake_list = []
+    gear_list = []
+    drs_list = []
+    
+    for frame in frames:
+        t_list.append(frame['t'])
+        tel = frame.get('telemetry', frame)  # Support both nested and flat formats
+        dist_list.append(tel.get('dist', 0))
+        speed_list.append(tel.get('speed', 0))
+        throttle_list.append(tel.get('throttle', 0))
+        brake_list.append(tel.get('brake', 0))
+        gear_list.append(tel.get('gear', 0))
+        drs_list.append(tel.get('drs', 0))
+    
+    return {
+        't': np.array(t_list),
+        'dist': np.array(dist_list),
+        'speed': np.array(speed_list),
+        'throttle': np.array(throttle_list),
+        'brake': np.array(brake_list),
+        'gear': np.array(gear_list),
+        'drs': np.array(drs_list),
+    }
+
+
+def create_telemetry_comparison(
+    telemetry1: Dict,
+    telemetry2: Dict,
+    label1: str = "Lap 1",
+    label2: str = "Lap 2",
+    color1: Tuple[float, float, float] = (0.0, 0.8, 0.4),
+    color2: Tuple[float, float, float] = (0.8, 0.2, 0.2),
+    num_points: int = 1000,
+    lap_time1: Optional[float] = None,
+    lap_time2: Optional[float] = None,
+) -> TelemetryComparison:
+    """
+    Create a complete telemetry comparison object from two telemetry datasets.
+    
+    Args:
+        telemetry1: First telemetry dataset
+        telemetry2: Second telemetry dataset
+        label1: Label for first lap (e.g., "VER Q3")
+        label2: Label for second lap (e.g., "HAM Q3")
+        color1: RGB tuple for lap 1 traces
+        color2: RGB tuple for lap 2 traces
+        num_points: Number of distance points for interpolation
+        lap_time1: Total lap time for lap 1 (seconds)
+        lap_time2: Total lap time for lap 2 (seconds)
+        
+    Returns:
+        TelemetryComparison object with aligned data
+    """
+    # Align telemetry to common distance axis
+    distance, interp1, interp2 = align_telemetry_by_distance(
+        telemetry1, telemetry2, num_points
+    )
+    
+    # Calculate delta time
+    delta_time = calculate_delta_time(distance, interp1['t'], interp2['t'])
+    
+    return TelemetryComparison(
+        distance=distance,
+        lap1_speed=interp1['speed'],
+        lap2_speed=interp2['speed'],
+        lap1_throttle=interp1['throttle'],
+        lap2_throttle=interp2['throttle'],
+        lap1_brake=interp1['brake'],
+        lap2_brake=interp2['brake'],
+        lap1_gear=interp1['gear'],
+        lap2_gear=interp2['gear'],
+        lap1_drs=interp1['drs'],
+        lap2_drs=interp2['drs'],
+        delta_time=delta_time,
+        lap1_label=label1,
+        lap2_label=label2,
+        lap1_color=color1,
+        lap2_color=color2,
+        lap1_time=lap_time1,
+        lap2_time=lap_time2,
+    )


### PR DESCRIPTION
- Add compare module for distance-based telemetry interpolation
- Create Matplotlib multi-panel chart (Speed, Throttle/Brake, Delta Time)
- Add CLI support with --compare flag (interactive and quick modes)
- Update README with usage documentation


The Goal: Allow users to select two laps (e.g., Driver A vs Driver B or Lap 1 vs Lap 50) and generate a multi-panel chart comparing their Speed, Throttle, and Brake traces indexed by distance.

Responding to #170 

