### PR TITLE
fixed a few issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,26 +3,27 @@ from src.arcade_replay import run_arcade_replay
 
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
+import argparse
 from src.cli.race_selection import cli_load
 from src.gui.race_selection import RaceSelectionWindow
 from PySide6.QtWidgets import QApplication
 
-def main(year=None, round_number=None, playback_speed=1, session_type='R', visible_hud=True, ready_file=None):
+def main(year=None, round_number=None, playback_speed=1, session_type='R', visible_hud=True, ready_file=None, refresh_data=False):
   print(f"Loading F1 {year} Round {round_number} Session '{session_type}'")
   session = load_session(year, round_number, session_type)
 
   print(f"Loaded session: {session.event['EventName']} - {session.event['RoundNumber']} - {session_type}")
 
-  # Enable cache for fastf1
+  # enable cache for fastf1
   enable_cache()
 
   if session_type == 'Q' or session_type == 'SQ':
 
-    # Get the drivers who participated and their lap times
+    # get the drivers who participated and their lap times
 
-    qualifying_session_data = get_quali_telemetry(session, session_type=session_type)
+    qualifying_session_data = get_quali_telemetry(session, session_type=session_type, refresh=refresh_data)
 
-    # Run the arcade screen showing qualifying results
+    # run the arcade screen showing qualifying results
 
     title = f"{session.event['EventName']} - {'Sprint Qualifying' if session_type == 'SQ' else 'Qualifying Results'}"
     
@@ -35,12 +36,12 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
 
   else:
 
-    # Get the drivers who participated in the race
+    # get the drivers who participated in the race
 
-    race_telemetry = get_race_telemetry(session, session_type=session_type)
+    race_telemetry = get_race_telemetry(session, session_type=session_type, refresh=refresh_data)
 
-    # Get example lap for track layout
-    # Qualifying lap preferred for DRS zones (fallback to fastest race lap (no DRS data))
+    # get example lap for track layout
+    # qualifying lap preferred for drs zones (fallback to fastest race lap (no drs data))
     example_lap = None
     
     try:
@@ -56,7 +57,7 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
     except Exception as e:
         print(f"Could not load qualifying session: {e}")
 
-    # fallback: Use fastest race lap
+    # fallback: use fastest race lap
     if example_lap is None:
         fastest_lap = session.laps.pick_fastest()
         if fastest_lap is not None:
@@ -68,14 +69,14 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
 
     drivers = session.drivers
 
-    # Get circuit rotation
+    # get circuit rotation
 
     circuit_rotation = get_circuit_rotation(session)
     
-    # Prepare session info for display banner
+    # prepare session info for display banner
     session_info = {
         'event_name': session.event.get('EventName', ''),
-        'circuit_name': session.event.get('Location', ''),  # Circuit location/name
+        'circuit_name': session.event.get('Location', ''),  # circuit location/name
         'country': session.event.get('Country', ''),
         'year': year,
         'round': round_number,
@@ -83,7 +84,7 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
         'total_laps': race_telemetry['total_laps']
     }
 
-    # Run the arcade replay
+    # run the arcade replay
 
     run_arcade_replay(
       frames=race_telemetry['frames'],
@@ -101,52 +102,60 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
     )
 
 if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="F1 Race Replay CLI")
 
-  if "--cli" in sys.argv:
-    # Run the CLI
+  parser.add_argument("--cli", action="store_true", help="Run the CLI mode")
+  parser.add_argument("--year", type=int, default=2025, help="Year of the season (default: 2025)")
+  parser.add_argument("--round", type=int, default=12, help="Round number (default: 12)")
+  parser.add_argument("--list-rounds", action="store_true", help="List all rounds for the specified year")
+  parser.add_argument("--list-sprints", action="store_true", help="List sprint races for the specified year")
+  
+  # viewer options
+  parser.add_argument("--viewer", action="store_true", help="Launch the viewer directly")
+  parser.add_argument("--no-hud", action="store_true", help="Hide the HUD in viewer mode")
+  parser.add_argument("--ready-file", type=str, help="Path to a file to signal readiness")
+  parser.add_argument("--refresh-data", action="store_true", help="Force refresh of cached data")
+  
+  # session type flags
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument("--qualifying", action="store_true", help="Load qualifying session")
+  group.add_argument("--sprint-qualifying", action="store_true", help="Load sprint qualifying session")
+  group.add_argument("--sprint", action="store_true", help="Load sprint race session")
 
+  args = parser.parse_args()
+
+  if args.cli:
     cli_load()
     sys.exit(0)
 
-  if "--year" in sys.argv:
-    year_index = sys.argv.index("--year") + 1
-    year = int(sys.argv[year_index])
-  else:
-    year = 2025  # Default year
-
-  if "--round" in sys.argv:
-    round_index = sys.argv.index("--round") + 1
-    round_number = int(sys.argv[round_index])
-  else:
-    round_number = 12  # Default round number
-
-  if "--list-rounds" in sys.argv:
-    list_rounds(year)
-  elif "--list-sprints" in sys.argv:
-    list_sprints(year)
-  else:
-    playback_speed = 1
-
-  if "--viewer" in sys.argv:
+  if args.list_rounds:
+    list_rounds(args.year)
+    sys.exit(0)
   
-    visible_hud = True
-    if "--no-hud" in sys.argv:
-      visible_hud = False
+  if args.list_sprints:
+    list_sprints(args.year)
+    sys.exit(0)
 
-    # Session type selection
-    session_type = 'SQ' if "--sprint-qualifying" in sys.argv else ('S' if "--sprint" in sys.argv else ('Q' if "--qualifying" in sys.argv else 'R'))
+  if args.viewer:
+    session_type = 'R'
+    if args.qualifying:
+      session_type = 'Q'
+    elif args.sprint_qualifying:
+      session_type = 'SQ'
+    elif args.sprint:
+      session_type = 'S'
+    
+    main(
+      year=args.year, 
+      round_number=args.round, 
+      session_type=session_type, 
+      visible_hud=not args.no_hud, 
+      ready_file=args.ready_file,
+      refresh_data=args.refresh_data
+    )
+    sys.exit(0)
 
-    # Optional ready-file path used when spawned from the GUI to signal ready state
-    ready_file = None
-    if "--ready-file" in sys.argv:
-      idx = sys.argv.index("--ready-file") + 1
-      if idx < len(sys.argv):
-        ready_file = sys.argv[idx]
-
-    main(year, round_number, playback_speed, session_type=session_type, visible_hud=visible_hud, ready_file=ready_file)
-
-  # Run the GUI
-
+  # run the gui if no other mode is selected
   app = QApplication(sys.argv)
   win = RaceSelectionWindow()
   win.show()


### PR DESCRIPTION
replaced manual sys.argv parsing with the standard argparse library.
       this provides better argument handling, automatic type conversion, and a generated help message (--help).
       maintained full backward compatibility with the existing cli flags used by the gui and cli loaders.
fixed cache & pathing:
       sanitized filenames fixed an issue where filenames containing colons (from session names) would fail on Windows.
       constants: added CACHE_DIR (.fastf1-cache) and COMPUTED_DIR (computed_data) constants to the top of the file for easier configuration and to prevent hardcoding strings in multiple places.
       cleaned up arguments: replaced the direct inspection of sys.argv for --refresh-data with a clean function argument refresh=False.
optimized multiprocessing:
       safe defaults: added MAX_WORKERS = 4 constant to limit the number of parallel processes.
       no more oom: the code now spawns min(MAX_WORKERS, cpu_count(), n_drivers) processes instead of one per driver (which could spawn 20+ heavy processes and crash systems with limited RAM).

tested all changes, made sure the cli arg parsing works (eg, python main.py --list-rounds --year 2024). made sure that fetching race telemetry works, correctly caches data, and saves it to the computed_data directory with a valid Windows filename.