### PR TITLE
Fix controls popup layout alignment

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -1028,29 +1028,41 @@ class ControlsPopupComponent(BaseComponent):
         self._header_text.draw()
 
 
-        lines = [
-            " ",
-            "[SPACE] Pause/Resume",
-            "← / →  Jump back/forward",
-            "↑ / ↓  Speed +/-",
-            "[1-4]  Set speed: 0.5x / 1x / 2x / 4x",
-            "[R]    Restart",
-            "[D]    Toggle DRS Zones",
-            "[B]    Toggle Progress Bar",
-            "[L]    Toggle Driver Labels",
-            "[H]    Toggle Help Popup",
+        controls = [
+            ("SPACE", "Pause/Resume"),
+            ("← / →", "Jump back/forward"),
+            ("↑ / ↓", "Speed +/-"),
+            ("1-4", "Set speed: 0.5x / 1x / 2x / 4x"),
+            ("R", "Restart"),
+            ("D", "Toggle DRS Zones"),
+            ("B", "Toggle Progress Bar"),
+            ("L", "Toggle Driver Labels"),
+            ("H", "Toggle Help Popup"),
         ]
-        
+
         line_spacing = max(18, int(self.body_font_size + 8))
-        y = header_cy - 20
-        for l in lines:
+        left_x = cx - self.width / 2 + 16
+        desc_x = cx - self.width / 2 + 100  # Fixed position for descriptions
+        y = header_cy - 35  # More space below header
+
+        for key, desc in controls:
+            # Draw key
             self._body_text.font_size = self.body_font_size
-            self._body_text.bold = False
-            self._body_text.color = arcade.color.LIGHT_GRAY
-            self._body_text.text = l
-            self._body_text.x = cx - self.width / 2 + 16
+            self._body_text.bold = True
+            self._body_text.color = arcade.color.WHITE
+            self._body_text.text = key
+            self._body_text.x = left_x
             self._body_text.y = y
             self._body_text.draw()
+
+            # Draw description
+            self._body_text.bold = False
+            self._body_text.color = arcade.color.LIGHT_GRAY
+            self._body_text.text = desc
+            self._body_text.x = desc_x
+            self._body_text.y = y
+            self._body_text.draw()
+
             y -= line_spacing
 
     def on_mouse_press(self, window, x: float, y: float, button: int, modifiers: int):


### PR DESCRIPTION
## Summary
- Use two-column layout with fixed x positions instead of space-based alignment
- Keys are rendered bold/white at a fixed left position, descriptions rendered gray at a fixed right position
- This fixes the inconsistent spacing issue since the font is not monospace and characters like arrows have different widths

## Before
![before](https://github.com/IAmTomShaw/f1-race-replay/issues/65)
Keys and descriptions had inconsistent spacing due to variable character widths in the proportional font.

<img width="361" height="270" alt="Screenshot 2026-02-01 at 2 17 16 PM" src="https://github.com/user-attachments/assets/1af1b9b2-cda2-4a53-92cc-83786d1926a3" />


## After
Keys and descriptions are now properly aligned using fixed column positions.

<img width="354" height="266" alt="Screenshot 2026-02-01 at 2 18 33 PM" src="https://github.com/user-attachments/assets/82e7fd16-4f46-4a1a-9957-8d7cfd96bed9" />


## Test plan
- [x] Run the app and open a race replay
- [x] Press H to open the controls popup
- [x] Verify keys and descriptions are properly aligned

Fixes #65