### PR TITLE
Fix typo in DRS Zone toggle instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Python application for visualizing Formula 1 race telemetry and replaying race
 - **Playback Speed:** ↑ / ↓ or Speed button (cycles through 0.5x, 1x, 2x, 4x)
 - **Set Speed Directly:** Keys 1–4
 - **Restart**: **R** to restart replay
-- **Toggle DRS Zone**: **D** to hide/showi DRS Zone
+- **Toggle DRS Zone**: **D** to hide/show DRS Zone
 - **Toggle Progress Bar**: **B** to hide/show progress bar
 - **Toggle Driver Names**: **L** to hide/show driver names on track
 - **Select driver/drivers**: Click to select driver or shift click to select multiple drivers


### PR DESCRIPTION
Changed the instructions from Toggle DRS Zone: D to hide/showi DRS Zone to Toggle DRS Zone: D to hide/show DRS Zone