### PR TITLE
Enhance Race Selection UI with Race-Wise Filtering and Window Behavior Improvements

### DIFF
--- a/src/gui/race_selection.py
+++ b/src/gui/race_selection.py
@@ -368,10 +368,6 @@ class RaceSelectionWindow(QMainWindow):
                         except Exception:
                             pass
                         timer.stop()
-
-                        #Minimize RaceSelectionWindow
-                        self.showMinimized()
-                        
                         try:
                             os.remove(ready_path)
                         except Exception:

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -55,7 +55,7 @@ class F1RaceReplayWindow(arcade.Window):
         self.playback_speed = PLAYBACK_SPEEDS[PLAYBACK_SPEEDS.index(playback_speed)] if playback_speed in PLAYBACK_SPEEDS else 1.0
         self.driver_colors = driver_colors or {}
         self.frame_index = 0.0  # use float for fractional-frame accumulation
-        self.paused = True
+        self.paused = False
         self.total_laps = total_laps
         self.has_weather = any("weather" in frame for frame in frames) if frames else False
         self.visible_hud = visible_hud # If it displays HUD or not (leaderboard, controls, weather, etc)


### PR DESCRIPTION
## Summary
This PR introduces an improvement in the race selection GUI by adding a **race-wise filter** that allows users to view the same Grand Prix across different years, enabling easier historical comparison.  

Additionally, minor UI improvement are introduced for a better user experience

## Changes Introduced

### 1. Race-Wise Filtering
- Added a **race-name based filter** in the Race Selection UI.
- Enables easier **cross-year performance comparison** and historical analysis.
- Implemented independent filtering logic so users can filter either by **Year** or **Race Name**, avoiding conflicting filters.

### 2. Automatic Window Minimization
- Automatically minimizing the Race Selection Window when the arcade is fully initialized.
- Preventing visual clutter and improving the overall UX flow.

### 3. Race Replay Paused By Default
- Letting the race replay be paused by default, giving the user the freedom to 
    - start the replay on their own, 
    - setup customizations for the display before starting
    - not miss the initial lap
- Improved User Experience

### 4. Minor Fixes
- Cleaned up unused imports.

## Motivation
These changes aim to improve both usability and workflow efficiency for users exploring race replays, especially for multi-year comparisons and smoother UI transitions.

## P.S.
This is my first-ever open source contribution and would love some feedback. 
Love Formula 1, and Love the project ❤️