### PR TITLE
Fix missing DRS zones by falling back to previous year qualifying data

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from src.f1_data import get_race_telemetry, enable_cache, get_circuit_rotation, load_session, get_quali_telemetry, list_rounds, list_sprints, get_previous_year_drs_data
+from src.f1_data import get_race_telemetry, enable_cache, get_circuit_rotation, load_session, get_quali_telemetry, list_rounds, list_sprints, inject_drs_from_previous_year
 from src.run_session import run_arcade_replay, launch_insights_menu
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
@@ -65,32 +65,7 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
             print("Error: No valid laps found in session")
             return
 
-    # If the example_lap has no meaningful DRS activations, try to borrow
-    # DRS zone data from the previous year's qualifying for the same circuit.
-    has_active_drs = (
-        'DRS' in example_lap.columns
-        and any(val in (10, 12, 14) for val in example_lap['DRS'])
-    )
-    if not has_active_drs:
-        import numpy as np
-        event_name = session.event['EventName']
-        print(f"No DRS activations in example lap. Trying previous year's qualifying for '{event_name}'...")
-        prev_drs = get_previous_year_drs_data(event_name, year)
-        if prev_drs is not None:
-            prev_rel_dist, prev_drs_vals = prev_drs
-            order = np.argsort(prev_rel_dist)
-            prev_rel_sorted = prev_rel_dist[order]
-            prev_drs_sorted = prev_drs_vals[order]
-
-            curr_rel_dist = example_lap['RelativeDistance'].to_numpy()
-            idxs = np.searchsorted(prev_rel_sorted, curr_rel_dist, side='right') - 1
-            idxs = np.clip(idxs, 0, len(prev_rel_sorted) - 1)
-
-            example_lap = example_lap.copy()
-            example_lap['DRS'] = prev_drs_sorted[idxs]
-            print(f"DRS zones mapped from {year - 1} qualifying onto current track layout")
-        else:
-            print("No previous year DRS data available. DRS zones will not be shown.")
+    example_lap = inject_drs_from_previous_year(example_lap, session.event['EventName'], year)
 
     drivers = session.drivers
 

--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -950,42 +950,59 @@ def get_quali_telemetry(session, session_type="Q"):
     }
 
 
-def get_previous_year_drs_data(event_name, year):
-    """Try to get DRS activation data from the previous year's qualifying for the same event.
+def inject_drs_from_previous_year(example_lap, event_name, year):
+    """Inject DRS zone data from the previous year's qualifying into example_lap.
 
-    When a session's telemetry lacks DRS data (e.g. 2025 Las Vegas GP),
-    we can borrow DRS zone positions from the previous year's qualifying
-    since the circuit layout and DRS zones are typically identical.
+    When a session's telemetry lacks DRS activation data (e.g. 2025 Las Vegas GP),
+    this loads the previous year's qualifying for the same circuit and maps its DRS
+    values onto the current example_lap using RelativeDistance.
 
-    Returns (rel_dist_array, drs_array) or None if unavailable.
+    Returns the example_lap with DRS data injected, or unchanged if unavailable.
     """
+    has_active_drs = (
+        'DRS' in example_lap.columns
+        and np.any(np.isin(example_lap['DRS'].to_numpy(), [10, 12, 14]))
+    )
+    if has_active_drs:
+        return example_lap
+
     enable_cache()
     prev_year = year - 1
+    print(f"No DRS activations in example lap. Trying {prev_year} qualifying for '{event_name}'...")
     try:
         schedule = fastf1.get_event_schedule(prev_year)
         matching = schedule[schedule['EventName'] == event_name]
         if matching.empty:
-            return None
+            return example_lap
         round_number = int(matching.iloc[0]['RoundNumber'])
         prev_session = load_session(prev_year, round_number, 'Q')
         if prev_session is None or len(prev_session.laps) == 0:
-            return None
+            return example_lap
         fastest = prev_session.laps.pick_fastest()
         if fastest is None:
-            return None
+            return example_lap
         telemetry = fastest.get_telemetry()
         if 'DRS' not in telemetry.columns:
-            return None
-        drs_vals = telemetry['DRS'].to_numpy()
-        if not np.any(np.isin(drs_vals, [10, 12, 14])):
-            return None
-        return (
-            telemetry['RelativeDistance'].to_numpy(),
-            drs_vals,
-        )
+            return example_lap
+        prev_drs = telemetry['DRS'].to_numpy()
+        if not np.any(np.isin(prev_drs, [10, 12, 14])):
+            return example_lap
+
+        prev_rel = telemetry['RelativeDistance'].to_numpy()
+        order = np.argsort(prev_rel)
+        prev_rel_sorted = prev_rel[order]
+        prev_drs_sorted = prev_drs[order]
+
+        curr_rel = example_lap['RelativeDistance'].to_numpy()
+        idxs = np.clip(np.searchsorted(prev_rel_sorted, curr_rel, side='right') - 1, 0, len(prev_rel_sorted) - 1)
+
+        example_lap = example_lap.copy()
+        example_lap['DRS'] = prev_drs_sorted[idxs]
+        print(f"DRS zones mapped from {prev_year} qualifying onto current track layout")
+        return example_lap
     except Exception as e:
         print(f"Could not load {prev_year} qualifying for DRS fallback: {e}")
-        return None
+        return example_lap
 
 
 def get_race_weekends_by_year(year):


### PR DESCRIPTION
When a session's telemetry lacks DRS activation data (e.g. 2025 Las Vegas GP), the app now automatically loads the previous year's qualifying for the same circuit and maps its DRS zones onto the current track layout.

Fixes #89

<img width="1619" height="1039" alt="Screenshot 2026-03-02 at 15 03 51" src="https://github.com/user-attachments/assets/d6d179d2-72fc-4669-858e-bff18b57c75b" />
