### PR TITLE
Pit-stop indicator for the leaderboard

### DIFF
--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -13,7 +13,6 @@ from src.lib.settings import get_settings
 from src.lib.time import parse_time_string
 from src.lib.tyres import get_tyre_compound_int
 
-
 def enable_cache():
     # Get cache location from settings
     settings = get_settings()
@@ -724,6 +723,39 @@ def get_race_telemetry(session, session_type="R"):
         except Exception as e:
             print(f"Weather data could not be processed: {e}")
 
+    #4.2. Aggregating Driver pit-in and pit-out data for Pitstop leaderboard indicator
+    pit_windows={}
+    laps=session.laps
+
+    for driver_no in drivers:
+        drv=session.get_driver(driver_no)["Abbreviation"]
+        driver_laps=laps.pick_drivers(drv)
+        windows=[]
+
+        for _, lap in driver_laps.iterrows():
+            pit_in=lap.get("PitInTime")
+            pit_out=lap.get("PitOutTime")
+
+            if pd.notna(pit_in):
+                start=pit_in.total_seconds()
+                if pd.notna(pit_out):
+                    end=pit_out.total_seconds()
+                else:
+                    end=start+40 #Error Rare case
+                
+                windows.append((start,end))
+        pit_windows[drv]=windows
+    
+    #Adjusting pit windows to the telemetry timeline
+    pit_windows_shifted={}
+    for drv, windows in pit_windows.items():
+        shifted=[]
+        for start,end in windows:
+            shifted.append((start-global_t_min,end-global_t_min))
+        pit_windows_shifted[drv]=shifted
+    
+    print("PIT WINDOWS: ", pit_windows)
+
     # 5. Build the frames + LIVE LEADERBOARD
     frames = []
     num_frames = len(timeline)
@@ -773,6 +805,13 @@ def get_race_telemetry(session, session_type="R"):
             code = car["code"]
             position = idx + 1
 
+            #Pit stop detection
+            in_pit=False
+            for start,end in pit_windows_shifted.get(code,[]):
+                if start<=t<=end:
+                    in_pit=True
+                    break
+            
             # include speed, gear, drs_active in frame driver dict
             frame_data[code] = {
                 "x": car["x"],
@@ -788,6 +827,7 @@ def get_race_telemetry(session, session_type="R"):
                 "drs": car["drs"],
                 "throttle": car["throttle"],
                 "brake": car["brake"],
+                "in_pit": in_pit
             }
 
         weather_snapshot = {}

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -396,8 +396,27 @@ class LeaderboardComponent(BaseComponent):
                 text_color = arcade.color.BLACK
             else:
                 text_color = color
-            text = f"{current_pos}. {code}" if pos.get("rel_dist",0) != 1 else f"{current_pos}. {code}   OUT"
-            arcade.Text(text, left_x, top_y, text_color, 16, anchor_x="left", anchor_y="top").draw()
+
+            text = f"{current_pos}. {code}" 
+            if pos.get("rel_dist",0) != 1:
+                out_text=""
+            else:
+                out_text="  OUT"
+
+            if pos.get("in_pit"):
+                driver_text = text
+                pit_text="  PIT"
+            else:
+                driver_text = text
+                pit_text = ""
+
+            arcade.Text(driver_text,left_x,top_y,text_color,16,anchor_x="left",anchor_y="top").draw()
+            
+            #PIT indicator in white
+            if pit_text:arcade.Text(pit_text, left_x + 80, top_y,arcade.color.WHITE,16,anchor_x="left",anchor_y="top").draw()
+
+            #OUT indicator in team_color
+            if out_text: arcade.Text(out_text, left_x + 80, top_y, (155,17,30), 16, anchor_x="left", anchor_y="top",bold=True).draw()
 
             # Gap display (if enabled)
             if getattr(self, "show_neighbor_gaps", False):
@@ -514,6 +533,8 @@ class LeaderboardComponent(BaseComponent):
                 drs_dot_y = tyre_icon_y
 
                 arcade.draw_circle_filled(drs_dot_x, drs_dot_y, 4, drs_color)
+
+        
 
         # Add text at the bottom of the leaderboard during lap 1 to alert the user to potential mis-ordering
         if new_entries[0][2].get("lap", 0) == 1:

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -415,7 +415,7 @@ class LeaderboardComponent(BaseComponent):
             #PIT indicator in white
             if pit_text:arcade.Text(pit_text, left_x + 80, top_y,arcade.color.WHITE,16,anchor_x="left",anchor_y="top").draw()
 
-            #OUT indicator in team_color
+            #OUT indicator in red
             if out_text: arcade.Text(out_text, left_x + 80, top_y, (155,17,30), 16, anchor_x="left", anchor_y="top",bold=True).draw()
 
             # Gap display (if enabled)


### PR DESCRIPTION
## Summary
This PR adds a **PIT indicator** to the race replay leaderboard to show when a driver is currently in the pit lane during a race replay.

The indicator is displayed as **PIT** next to the driver name and is rendered in white so that it remains visually distinct.

## Changes
- Implemented pit lane detection using FastF1 lap data:
  - `PitInTime`
  - `PitOutTime`
- Computed pit windows for each driver during telemetry preprocessing.
- Added an `in_pit` flag to driver frame data.
- Updated leaderboard rendering to display a **PIT indicator** when a driver is inside the pit lane.

The existing **OUT indicator** was already present but its color was modified for better readability.

## Example
<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/f0a94895-4583-4237-bed8-fd2e9a3b039b" />

## Motivation
This improves race replay readability by making pit stops visible on the leaderboard and highlighting their impact on race order and strategy.

## Future Work
This PR aims to lay the groundwork for a visual pit-entry and exit sim addition, where cars entering the pit lane can be shown during the replay to better represent pit stop events.