### PR TITLE
Add live race viewer via OpenF1 API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from src.f1_data import get_race_telemetry, enable_cache, get_circuit_rotation, load_session, get_quali_telemetry, list_rounds, list_sprints
-from src.run_session import run_arcade_replay, launch_insights_menu
+from src.run_session import run_arcade_replay, launch_insights_menu, run_live_arcade_replay
 from src.interfaces.qualifying import run_qualifying_replay
 import sys
 from src.cli.race_selection import cli_load
@@ -108,6 +108,143 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
       enable_telemetry=True # This is now permanently enabled to support the telemetry insights menu if the user decides to use it
     )
 
+def live_main(ready_file=None):
+  """Entry point for live race viewing via OpenF1."""
+  import datetime
+  import time as _time
+  import fastf1
+  from src.live_f1_data import (
+      get_current_session, is_session_live,
+      get_session_drivers, get_driver_colors_from_openf1,
+      find_round_number, load_circuit_layout, LiveDataFeed,
+  )
+
+  print("Checking for a live F1 session via OpenF1…")
+  session_info = get_current_session()
+
+  if not session_info:
+    print("Error: Could not reach the OpenF1 API. Check your internet connection.")
+    return
+
+  location     = session_info.get("location", "Unknown")
+  session_name = session_info.get("session_name", "Unknown")
+  year         = int(session_info.get("year", get_season()))
+  session_key  = int(session_info["session_key"])
+
+  if not is_session_live(session_info):
+    date_start = session_info.get("date_start", "")
+    print(f"No live session right now.")
+    print(f"Most recent: {location} — {session_name}  ({date_start})")
+    print("Run with --live again when a session is in progress.")
+    return
+
+  print(f"Live session: {location} — {session_name}  (session key {session_key})")
+
+  # ---- Drivers --------------------------------------------------------
+  print("Fetching driver list…")
+  drivers_info  = get_session_drivers(session_key)
+  driver_colors = get_driver_colors_from_openf1(drivers_info)
+  drivers       = [info.get("name_acronym", num) for num, info in drivers_info.items()]
+  print(f"  {len(drivers_info)} drivers found")
+
+  # ---- Circuit layout from FastF1 -------------------------------------
+  enable_cache()
+  circuit_short = session_info.get("circuit_short_name", "")
+
+  print("Finding round number from FastF1 schedule…")
+  round_number = find_round_number(year, location, circuit_short)
+
+  example_lap      = None
+  circuit_rotation = 0.0
+  fastf1_session   = None
+
+  if round_number:
+    print(f"  Round {round_number} — loading circuit layout from FastF1…")
+    example_lap, fastf1_session = load_circuit_layout(year, round_number)
+    if example_lap is not None and fastf1_session is not None:
+      circuit_rotation = get_circuit_rotation(fastf1_session)
+      # Refine driver colours from FastF1 where possible
+      try:
+        from src.f1_data import get_driver_colors as _gdc
+        ff1_colors = _gdc(fastf1_session)
+        driver_colors.update(ff1_colors)
+      except Exception:
+        pass
+  else:
+    print("  Could not find round number — trying previous-year layout…")
+    for prev_year in range(year - 1, max(year - 4, 2018), -1):
+      rn = find_round_number(prev_year, location, circuit_short)
+      if rn:
+        example_lap, _ = load_circuit_layout(prev_year, rn)
+        if example_lap is not None:
+          print(f"  Using circuit layout from {prev_year} Round {rn}")
+          break
+
+  if example_lap is None:
+    print("Error: Could not load circuit layout. Cannot open the visualiser.")
+    return
+
+  # ---- Live data feed -------------------------------------------------
+  date_start_str = session_info.get("date_start", "")
+  try:
+    session_start = datetime.datetime.fromisoformat(date_start_str.replace("Z", "+00:00"))
+  except Exception:
+    session_start = datetime.datetime.now(datetime.timezone.utc)
+
+  print("Prefetching live data from OpenF1…")
+  live_feed = LiveDataFeed(session_key, drivers_info, session_start)
+  live_feed.prefetch()
+
+  # Retry briefly if no positions arrived yet (session may have just started)
+  retries = 0
+  while live_feed.frame_count() == 0 and retries < 5:
+    print(f"  Waiting for position data… ({retries + 1}/5)")
+    _time.sleep(2)
+    live_feed.prefetch()
+    retries += 1
+
+  if live_feed.frame_count() == 0:
+    print("Warning: No position data received — the session may not have started yet.")
+    print("The viewer will open and wait for data.")
+
+  # Start background polling
+  live_feed.start()
+
+  # ---- Session info banner --------------------------------------------
+  circuit_length = None
+  if "Distance" in example_lap.columns:
+    circuit_length = float(example_lap["Distance"].max())
+
+  session_display_info = {
+    "event_name":      location,
+    "circuit_name":    location,
+    "country":         session_info.get("country_name", ""),
+    "year":            year,
+    "round":           round_number,
+    "date":            "LIVE",
+    "total_laps":      None,
+    "circuit_length_m": circuit_length,
+  }
+
+  # ---- Launch insights menu and visualiser ----------------------------
+  launch_insights_menu()
+
+  title = f"[LIVE] {location} — {session_name}"
+  print(f"Launching live viewer: {title}")
+
+  run_live_arcade_replay(
+    live_feed=live_feed,
+    example_lap=example_lap,
+    drivers=drivers,
+    driver_colors=driver_colors,
+    title=title,
+    circuit_rotation=circuit_rotation,
+    session_info=session_display_info,
+    session=fastf1_session,
+    ready_file=ready_file,
+  )
+
+
 if __name__ == "__main__":
 
   if "--verbose" not in sys.argv:# fastf1 logging is disabled by default
@@ -116,6 +253,15 @@ if __name__ == "__main__":
   if "--cli" in sys.argv:
     # Run the CLI
     cli_load()
+    sys.exit(0)
+
+  if "--live" in sys.argv:
+    ready_file = None
+    if "--ready-file" in sys.argv:
+      idx = sys.argv.index("--ready-file") + 1
+      if idx < len(sys.argv):
+        ready_file = sys.argv[idx]
+    live_main(ready_file=ready_file)
     sys.exit(0)
 
   if "--year" in sys.argv:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pyglet
 pyside6
 questionary
 rich
+requests
+scipy

--- a/src/cli/race_selection.py
+++ b/src/cli/race_selection.py
@@ -21,6 +21,23 @@ def cli_load():
     console = Console()
     console.print(Markdown("# F1 Race Replay 🏎️"))
 
+    # Offer Watch Live as the first option
+    mode_choices = [
+        Choice(title="Watch Live  (connect to live timing)", value="live"),
+        Choice(title="Watch Replay  (choose a past session)", value="replay"),
+    ]
+    mode = select("What would you like to do?", choices=mode_choices, qmark="🏁", style=style).ask()
+    if not mode:
+        sys.exit(0)
+
+    if mode == "live":
+        main_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'main.py'))
+        cmd = [sys.executable, main_path, "--live"]
+        if "--verbose" in sys.argv:
+            cmd.append("--verbose")
+        subprocess.run(cmd)
+        return
+
     years = [str(year) for year in range(current_year, 2009, -1)]
     year = select("Choose a year", choices=years, qmark="🗓️ ", style=style).ask()
     if not year:

--- a/src/interfaces/live_race.py
+++ b/src/interfaces/live_race.py
@@ -1,0 +1,202 @@
+"""
+Live race visualization window.
+
+Extends F1RaceReplayWindow to consume frames from a LiveDataFeed instead of
+a pre-computed replay.  The window always shows the most recent frame when
+un-paused; pressing SPACE freezes the view (DVR-style) and pressing SPACE
+again jumps back to live.
+"""
+
+import math
+import time
+
+import arcade
+
+from src.interfaces.race_replay import F1RaceReplayWindow
+from src.live_f1_data import LiveDataFeed
+from src.ui_components import extract_race_events
+
+
+class LiveRaceWindow(F1RaceReplayWindow):
+    """
+    Live F1 race viewer.
+
+    Differences from the replay window:
+    - Frames are supplied by a LiveDataFeed that grows over time.
+    - The frame index always advances to the latest frame (unless paused).
+    - Track statuses are synced from the feed on every update.
+    - Playback speed / seek controls are hidden and disabled.
+    - A pulsing "LIVE" badge is drawn in the top-right corner.
+    - Pressing SPACE freezes the view; pressing again jumps back to live.
+    """
+
+    def __init__(self, live_feed: LiveDataFeed, **kwargs):
+        # Feed provides the shared frames list (grows as data arrives)
+        self._live_feed = live_feed
+
+        # Pass the live frames list to the parent so self.frames is the same
+        # object — appends from the background thread are immediately visible.
+        kwargs.setdefault("frames", live_feed.frames)
+        kwargs.setdefault("track_statuses", [])
+        kwargs.setdefault("total_laps", None)
+        # No tyre degradation for live (no historical session data)
+        kwargs["session"] = kwargs.get("session", None)
+
+        super().__init__(**kwargs)
+
+        # After parent init, jump to the latest frame
+        self.frame_index = float(max(0, self.n_frames - 1))
+
+        # Hide replay-specific UI elements that don't apply to live viewing
+        self.race_controls_comp.visible = False
+        # progress_bar_comp has no visible flag — monkeypatch its draw methods
+        self.progress_bar_comp.draw = lambda _: None
+        self.progress_bar_comp.draw_overlays = lambda _: None
+
+        # Whether the user has manually paused to review an older moment
+        self._user_paused = False
+
+        # Timestamp tracking for the live badge pulse
+        self._live_badge_phase = 0.0
+
+    # ------------------------------------------------------------------
+    # Core overrides
+    # ------------------------------------------------------------------
+
+    def on_update(self, delta_time: float):
+        self._live_badge_phase += delta_time
+
+        # Sync track statuses from the feed
+        new_statuses = self._live_feed.get_track_statuses()
+        if new_statuses is not self.track_statuses:
+            self.track_statuses = new_statuses
+
+        # Sync the frame count — the frames list grows in the background
+        new_count = len(self.frames)
+        if new_count > self.n_frames:
+            self.n_frames = new_count
+
+        if self._user_paused or self.n_frames == 0:
+            return
+
+        # Jump to the latest frame so we always show live data
+        self.frame_index = float(self.n_frames - 1)
+
+        # Broadcast telemetry for any connected insights windows
+        self._broadcast_telemetry_state()
+
+    def on_draw(self):
+        # Show a loading screen until the first frame arrives
+        if self.n_frames == 0 or not self.frames:
+            self._draw_loading_screen()
+            return
+
+        # Ensure frame_index is within bounds after a sync
+        self.frame_index = min(self.frame_index, float(self.n_frames - 1))
+
+        # Parent handles all track / driver / UI drawing
+        super().on_draw()
+
+        # Draw the LIVE badge on top of everything
+        self._draw_live_badge()
+
+        # If the user has paused, show a hint
+        if self._user_paused:
+            self._draw_paused_hint()
+
+    # ------------------------------------------------------------------
+    # Key handling — disable replay-only controls
+    # ------------------------------------------------------------------
+
+    def on_key_press(self, symbol: int, modifiers: int):
+        # ESC: close
+        if symbol == arcade.key.ESCAPE:
+            arcade.close_window()
+            return
+
+        # SPACE: DVR-style pause/resume
+        if symbol == arcade.key.SPACE:
+            self._user_paused = not self._user_paused
+            self.paused = self._user_paused
+            return
+
+        # Visual-only controls: pass through to parent
+        if symbol in (
+            arcade.key.D,   # DRS zone toggle
+            arcade.key.B,   # progress bar toggle (hidden, harmless)
+            arcade.key.L,   # driver label toggle
+            arcade.key.H,   # help popup
+        ):
+            super().on_key_press(symbol, modifiers)
+            return
+
+        # LEFT arrow: when paused, step back through buffered frames
+        if symbol == arcade.key.LEFT and self._user_paused:
+            step = max(1, int(self.n_frames * 0.01))  # ~1% of buffer
+            self.frame_index = max(0.0, self.frame_index - step)
+            return
+
+        # All other replay controls (speed, restart, seek) are not applicable
+
+    def on_key_release(self, symbol: int, modifiers: int):
+        # No hold-to-seek behaviour needed in live mode
+        pass
+
+    # ------------------------------------------------------------------
+    # Drawing helpers
+    # ------------------------------------------------------------------
+
+    def _draw_loading_screen(self):
+        self.clear()
+        cx, cy = self.width // 2, self.height // 2
+        arcade.draw_text(
+            "Connecting to live timing\u2026",
+            cx, cy + 20,
+            arcade.color.WHITE, 26,
+            anchor_x="center", anchor_y="center", bold=True,
+        )
+        arcade.draw_text(
+            "Fetching data from OpenF1 \u2014 this may take a few seconds",
+            cx, cy - 20,
+            (160, 160, 160), 15,
+            anchor_x="center", anchor_y="center",
+        )
+        # Animated dots
+        dots = "." * (int(self._live_badge_phase * 2) % 4)
+        arcade.draw_text(
+            dots,
+            cx, cy - 55,
+            (200, 200, 200), 22,
+            anchor_x="center", anchor_y="center",
+        )
+
+    def _draw_live_badge(self):
+        """Pulsing red dot + 'LIVE' label in the top-right corner."""
+        # Pulse between 60 % and 100 % brightness at ~1 Hz
+        pulse = 0.5 + 0.5 * math.sin(self._live_badge_phase * math.pi * 2)
+        r = int(200 + 55 * pulse)
+        badge_x = self.width - 16
+        badge_y = self.height - 16
+
+        # Red circle
+        arcade.draw_circle_filled(badge_x, badge_y, 7, (r, 40, 40))
+        arcade.draw_circle_outline(badge_x, badge_y, 7, (255, 80, 80), 1)
+
+        # "LIVE" text to the left of the dot
+        arcade.draw_text(
+            "LIVE",
+            badge_x - 12, badge_y,
+            (r, 40, 40), 13,
+            bold=True,
+            anchor_x="right", anchor_y="center",
+        )
+
+    def _draw_paused_hint(self):
+        """Small banner reminding the user they're in DVR review mode."""
+        msg = "PAUSED (reviewing buffer)  \u2190 step back   SPACE to go live"
+        arcade.draw_text(
+            msg,
+            self.width // 2, 62,
+            (240, 180, 0), 13,
+            anchor_x="center", anchor_y="center", bold=True,
+        )

--- a/src/live_f1_data.py
+++ b/src/live_f1_data.py
@@ -1,0 +1,506 @@
+"""
+Live F1 race data via the OpenF1 REST API.
+
+Polls OpenF1 (~1s interval) and builds frames in the same format used by
+F1RaceReplayWindow so the live viewer reuses the existing visualization.
+"""
+
+import datetime
+import threading
+import time
+from typing import Dict, List, Optional
+
+import requests
+
+OPENF1_BASE = "https://api.openf1.org/v1"
+
+# Maps OpenF1 compound strings to the int used by the replay engine
+TYRE_MAP = {
+    "SOFT": 0,
+    "MEDIUM": 1,
+    "HARD": 2,
+    "INTERMEDIATE": 3,
+    "WET": 4,
+    "UNKNOWN": 1,
+}
+
+# Maps OpenF1 race-control flag strings to the status codes used by the replay engine
+FLAG_STATUS_MAP = {
+    "GREEN": "1",
+    "YELLOW": "2",
+    "DOUBLE YELLOW": "2",
+    "RED": "5",
+    "SAFETY CAR": "4",
+    "VIRTUAL SAFETY CAR": "6",
+    "CHEQUERED": "1",
+    "CLEAR": "1",
+}
+
+
+def _hex_to_rgb(hex_color: str) -> tuple:
+    h = hex_color.lstrip("#")
+    if len(h) == 6:
+        return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
+    return (255, 255, 255)
+
+
+def _get(endpoint: str, params: Dict = None, timeout: int = 10) -> Optional[List]:
+    """GET request to OpenF1 API. Returns parsed JSON list or None on failure."""
+    url = f"{OPENF1_BASE}/{endpoint}"
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        print(f"[OpenF1] {endpoint} failed: {exc}")
+        return None
+
+
+def _parse_ts(date_str: Optional[str]) -> Optional[datetime.datetime]:
+    if not date_str:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def get_current_session() -> Optional[Dict]:
+    """
+    Return the most recent session from OpenF1, or None if the API is unreachable.
+    """
+    data = _get("sessions", {"session_key": "latest"})
+    if not data:
+        return None
+    return data[-1] if isinstance(data, list) else data
+
+
+def is_session_live(session: Dict) -> bool:
+    """
+    Return True if the session appears to be currently in progress.
+    Adds a 30-minute buffer after `date_end` to account for race overruns.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start = _parse_ts(session.get("date_start"))
+    end = _parse_ts(session.get("date_end"))
+    if start is None:
+        return False
+    if end is None:
+        # No end time recorded yet — live if start is within the last 4 hours
+        return start <= now <= start + datetime.timedelta(hours=4)
+    return start <= now <= end + datetime.timedelta(minutes=30)
+
+
+def get_session_drivers(session_key: int) -> Dict[str, Dict]:
+    """
+    Return driver info keyed by driver number (string).
+    e.g. {"1": {"name_acronym": "VER", "team_colour": "3671C6", ...}, ...}
+    """
+    data = _get("drivers", {"session_key": session_key}) or []
+    return {str(d["driver_number"]): d for d in data if "driver_number" in d}
+
+
+def get_driver_colors_from_openf1(drivers_info: Dict[str, Dict]) -> Dict[str, tuple]:
+    """Return {acronym: (R, G, B)} from OpenF1 driver info."""
+    colors = {}
+    for num, info in drivers_info.items():
+        code = info.get("name_acronym", num)
+        colors[code] = _hex_to_rgb(info.get("team_colour") or "FFFFFF")
+    return colors
+
+
+def load_circuit_layout(year: int, round_number: int):
+    """
+    Load an example lap from FastF1 for the circuit track layout.
+
+    Tries Qualifying first (best DRS data), then falls back to Race/Practice.
+    Returns (example_lap_df, session) or (None, None) on failure.
+    """
+    import fastf1  # local import — heavy library
+
+    for stype in ("Q", "R", "FP3", "FP2", "FP1"):
+        try:
+            session = fastf1.get_session(year, round_number, stype)
+            # Only load laps+telemetry; skip weather/messages to be faster
+            session.load(laps=True, telemetry=True, weather=False, messages=False)
+            fastest = session.laps.pick_fastest()
+            if fastest is not None:
+                tel = fastest.get_telemetry()
+                if not tel.empty and "X" in tel.columns:
+                    print(f"[Live] Circuit layout from {stype} (Round {round_number})")
+                    return tel, session
+        except Exception as exc:
+            print(f"[Live] Could not load {stype} for layout: {exc}")
+    return None, None
+
+
+def find_round_number(year: int, location: str, circuit_short: str) -> Optional[int]:
+    """
+    Try to find the FastF1 round number for a circuit given its name/location.
+    Returns None if not found.
+    """
+    try:
+        import fastf1
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+        loc_lower = location.lower()
+        circ_lower = circuit_short.lower()
+        for _, row in schedule.iterrows():
+            event_name = str(row.get("EventName", "")).lower()
+            event_loc = str(row.get("Location", "")).lower()
+            if circ_lower in event_name or circ_lower in event_loc or loc_lower in event_loc:
+                return int(row["RoundNumber"])
+    except Exception as exc:
+        print(f"[Live] Could not find round number: {exc}")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# LiveDataFeed
+# ---------------------------------------------------------------------------
+
+class LiveDataFeed:
+    """
+    Background poller that fetches live F1 data from OpenF1 and builds frames
+    compatible with F1RaceReplayWindow.
+
+    Frame format (matches existing replay frame structure):
+    {
+        "t":       float,   # seconds since session start (wall-clock)
+        "lap":     int,     # leader's current lap number
+        "drivers": {
+            "VER": {
+                "x": float, "y": float,
+                "position": int, "lap": int,
+                "dist": float, "rel_dist": float,
+                "tyre": int, "tyre_life": int,
+                "speed": float, "gear": int,
+                "drs": int, "throttle": float, "brake": float,
+            }, ...
+        },
+        "weather": {...} | None,
+    }
+    """
+
+    POLL_INTERVAL = 1.0  # seconds between polls
+
+    def __init__(
+        self,
+        session_key: int,
+        drivers_info: Dict[str, Dict],
+        session_start: datetime.datetime,
+    ):
+        self.session_key = session_key
+        self.drivers_info = drivers_info  # {driver_number_str: {name_acronym, ...}}
+        self.session_start = session_start
+
+        # Shared, lock-protected frame buffer (appended to by background thread)
+        self.frames: List[Dict] = []
+        self.track_statuses: List[Dict] = []  # live track status events
+        self._lock = threading.Lock()
+        self._running = False
+
+        # Current best-known state per driver (keyed by driver number string)
+        self._positions: Dict[str, Dict] = {}
+        self._car_data: Dict[str, Dict] = {}
+        self._race_pos: Dict[str, int] = {}
+        self._laps: Dict[str, int] = {}
+        self._stints: Dict[str, Dict] = {}
+        self._weather: Optional[Dict] = None
+
+        # Watermarks for incremental fetching
+        self._ts_location: Optional[datetime.datetime] = None
+        self._ts_car: Optional[datetime.datetime] = None
+        self._ts_position: Optional[datetime.datetime] = None
+
+        # Current track flag status code (matches replay engine codes)
+        self._current_status_code: str = "1"  # GREEN
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def prefetch(self):
+        """Synchronously load initial state and build the first frame."""
+        self._fetch_stints()
+        self._fetch_laps()
+        self._fetch_positions_bulk()
+        self._fetch_locations_bulk()
+        self._fetch_car_data_bulk()
+        self._fetch_weather()
+        self._fetch_race_control()
+        frame = self._build_frame()
+        if frame:
+            with self._lock:
+                self.frames.append(frame)
+
+    def start(self):
+        """Start background polling thread."""
+        self._running = True
+        t = threading.Thread(target=self._poll_loop, daemon=True)
+        t.start()
+
+    def stop(self):
+        self._running = False
+
+    def get_frames(self) -> List[Dict]:
+        with self._lock:
+            return list(self.frames)
+
+    def frame_count(self) -> int:
+        with self._lock:
+            return len(self.frames)
+
+    def get_track_statuses(self) -> List[Dict]:
+        with self._lock:
+            return list(self.track_statuses)
+
+    # ------------------------------------------------------------------
+    # Polling
+    # ------------------------------------------------------------------
+
+    def _poll_loop(self):
+        poll_count = 0
+        while self._running:
+            try:
+                self._fetch_incremental()
+                # Refresh stints / laps / weather less often
+                if poll_count % 5 == 0:
+                    self._fetch_stints()
+                    self._fetch_laps()
+                    self._fetch_weather()
+                if poll_count % 10 == 0:
+                    self._fetch_race_control()
+                frame = self._build_frame()
+                if frame:
+                    with self._lock:
+                        self.frames.append(frame)
+            except Exception as exc:
+                print(f"[LiveDataFeed] Poll error: {exc}")
+            poll_count += 1
+            time.sleep(self.POLL_INTERVAL)
+
+    def _fetch_incremental(self):
+        """Fetch only data newer than our watermarks."""
+        # Locations
+        loc_params = {"session_key": self.session_key}
+        if self._ts_location:
+            loc_params["date>"] = self._ts_location.isoformat()
+        locs = _get("location", loc_params) or []
+        for loc in locs:
+            drv = str(loc.get("driver_number", ""))
+            if drv:
+                self._positions[drv] = {"x": loc.get("x", 0), "y": loc.get("y", 0)}
+                ts = _parse_ts(loc.get("date"))
+                if ts and (self._ts_location is None or ts > self._ts_location):
+                    self._ts_location = ts
+
+        # Car data
+        car_params = {"session_key": self.session_key}
+        if self._ts_car:
+            car_params["date>"] = self._ts_car.isoformat()
+        cars = _get("car_data", car_params) or []
+        for c in cars:
+            drv = str(c.get("driver_number", ""))
+            if drv:
+                self._car_data[drv] = {
+                    "speed": c.get("speed", 0),
+                    "gear": c.get("n_gear", 0),
+                    "drs": 1 if (c.get("drs") or 0) >= 10 else 0,
+                    "throttle": c.get("throttle", 0),
+                    "brake": c.get("brake", 0),
+                }
+                ts = _parse_ts(c.get("date"))
+                if ts and (self._ts_car is None or ts > self._ts_car):
+                    self._ts_car = ts
+
+        # Race positions
+        pos_params = {"session_key": self.session_key}
+        if self._ts_position:
+            pos_params["date>"] = self._ts_position.isoformat()
+        positions = _get("position", pos_params) or []
+        for p in positions:
+            drv = str(p.get("driver_number", ""))
+            if drv:
+                self._race_pos[drv] = p.get("position", 99)
+                ts = _parse_ts(p.get("date"))
+                if ts and (self._ts_position is None or ts > self._ts_position):
+                    self._ts_position = ts
+
+    # ------------------------------------------------------------------
+    # Bulk fetches (called on startup / periodic refresh)
+    # ------------------------------------------------------------------
+
+    def _fetch_locations_bulk(self):
+        locs = _get("location", {"session_key": self.session_key}) or []
+        for loc in locs:
+            drv = str(loc.get("driver_number", ""))
+            if drv:
+                self._positions[drv] = {"x": loc.get("x", 0), "y": loc.get("y", 0)}
+                ts = _parse_ts(loc.get("date"))
+                if ts and (self._ts_location is None or ts > self._ts_location):
+                    self._ts_location = ts
+
+    def _fetch_car_data_bulk(self):
+        cars = _get("car_data", {"session_key": self.session_key}) or []
+        for c in cars:
+            drv = str(c.get("driver_number", ""))
+            if drv:
+                self._car_data[drv] = {
+                    "speed": c.get("speed", 0),
+                    "gear": c.get("n_gear", 0),
+                    "drs": 1 if (c.get("drs") or 0) >= 10 else 0,
+                    "throttle": c.get("throttle", 0),
+                    "brake": c.get("brake", 0),
+                }
+                ts = _parse_ts(c.get("date"))
+                if ts and (self._ts_car is None or ts > self._ts_car):
+                    self._ts_car = ts
+
+    def _fetch_positions_bulk(self):
+        positions = _get("position", {"session_key": self.session_key}) or []
+        for p in positions:
+            drv = str(p.get("driver_number", ""))
+            if drv:
+                self._race_pos[drv] = p.get("position", 99)
+                ts = _parse_ts(p.get("date"))
+                if ts and (self._ts_position is None or ts > self._ts_position):
+                    self._ts_position = ts
+
+    def _fetch_stints(self):
+        stints = _get("stints", {"session_key": self.session_key}) or []
+        for s in stints:
+            drv = str(s.get("driver_number", ""))
+            if not drv:
+                continue
+            existing = self._stints.get(drv)
+            snum = s.get("stint_number", 1)
+            if not existing or snum >= existing.get("stint_number", 0):
+                self._stints[drv] = {
+                    "compound": (s.get("compound") or "UNKNOWN").upper(),
+                    "age_at_start": s.get("tyre_age_at_start") or 0,
+                    "lap_start": s.get("lap_start") or 1,
+                    "stint_number": snum,
+                }
+
+    def _fetch_laps(self):
+        laps = _get("laps", {"session_key": self.session_key}) or []
+        for lap in laps:
+            drv = str(lap.get("driver_number", ""))
+            lap_num = lap.get("lap_number") or 1
+            if drv and lap_num > self._laps.get(drv, 0):
+                self._laps[drv] = lap_num
+
+    def _fetch_weather(self):
+        weather = _get("weather", {"session_key": self.session_key}) or []
+        if weather:
+            w = weather[-1]
+            self._weather = {
+                "track_temp": w.get("track_temperature"),
+                "air_temp": w.get("air_temperature"),
+                "humidity": w.get("humidity"),
+                "wind_speed": w.get("wind_speed"),
+                "wind_direction": w.get("wind_direction"),
+                "rain_state": "RAINING" if w.get("rainfall") else "DRY",
+            }
+
+    def _fetch_race_control(self):
+        """Pull race control messages and update track_statuses list."""
+        msgs = _get("race_control", {"session_key": self.session_key}) or []
+        now_t = (
+            datetime.datetime.now(datetime.timezone.utc) - self.session_start
+        ).total_seconds()
+
+        new_statuses = []
+        for msg in msgs:
+            flag = (msg.get("flag") or "").upper()
+            category = (msg.get("category") or "").upper()
+            if category not in ("FLAG", "SAFETYCAR", "VIRTUALSC"):
+                continue
+            code = FLAG_STATUS_MAP.get(flag, "1")
+            ts = _parse_ts(msg.get("date"))
+            t = (
+                (ts - self.session_start).total_seconds()
+                if ts
+                else now_t
+            )
+            new_statuses.append({"status": code, "start_time": t, "end_time": None})
+
+        # Fill in end times: each status ends when the next begins
+        for i, s in enumerate(new_statuses):
+            if i + 1 < len(new_statuses):
+                s["end_time"] = new_statuses[i + 1]["start_time"]
+
+        with self._lock:
+            self.track_statuses = new_statuses
+
+        # Update current flag for quick reference
+        if new_statuses:
+            self._current_status_code = new_statuses[-1]["status"]
+
+    # ------------------------------------------------------------------
+    # Frame building
+    # ------------------------------------------------------------------
+
+    def _build_frame(self) -> Optional[Dict]:
+        if not self._positions:
+            return None
+
+        drivers_data: Dict[str, Dict] = {}
+
+        for drv_num, pos in self._positions.items():
+            if drv_num not in self.drivers_info:
+                continue
+
+            info = self.drivers_info[drv_num]
+            code = info.get("name_acronym") or drv_num
+            car = self._car_data.get(drv_num, {})
+            stint = self._stints.get(drv_num, {})
+            lap = int(self._laps.get(drv_num) or 1)
+            race_position = int(self._race_pos.get(drv_num) or 99)
+
+            # Tyre compound → int
+            compound = (stint.get("compound") or "UNKNOWN").upper()
+            tyre_int = TYRE_MAP.get(compound, 1)
+
+            # Tyre life: age at stint start + laps completed since stint start
+            age_at_start = int(stint.get("age_at_start") or 0)
+            lap_start = int(stint.get("lap_start") or 1)
+            tyre_life = max(1, age_at_start + max(0, lap - lap_start + 1))
+
+            drivers_data[code] = {
+                "x": float(pos.get("x") or 0),
+                "y": float(pos.get("y") or 0),
+                "position": race_position,
+                "lap": lap,
+                "dist": 0.0,
+                "rel_dist": 0.0,
+                "tyre": tyre_int,
+                "tyre_life": tyre_life,
+                "speed": float(car.get("speed") or 0),
+                "gear": int(car.get("gear") or 0),
+                "drs": int(car.get("drs") or 0),
+                "throttle": float(car.get("throttle") or 0),
+                "brake": float(car.get("brake") or 0),
+            }
+
+        if not drivers_data:
+            return None
+
+        # Session time: seconds elapsed since session start
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t = max(0.0, (now - self.session_start).total_seconds())
+
+        # Leader = driver in P1
+        leader = min(drivers_data.values(), key=lambda d: d["position"], default=None)
+        leader_lap = leader["lap"] if leader else 1
+
+        return {
+            "t": t,
+            "lap": leader_lap,
+            "drivers": drivers_data,
+            "weather": self._weather,
+        }

--- a/src/run_session.py
+++ b/src/run_session.py
@@ -6,6 +6,8 @@ import time
 import arcade
 from src.interfaces.race_replay import F1RaceReplayWindow
 from src.insights.telemetry_stream_viewer import main as telemetry_viewer_main
+from src.interfaces.live_race import LiveRaceWindow
+from src.live_f1_data import LiveDataFeed
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
                       playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None,
@@ -47,6 +49,41 @@ def launch_telemetry_viewer():
   
   viewer_thread = threading.Thread(target=start_viewer, daemon=True)
   viewer_thread.start()
+
+
+def run_live_arcade_replay(
+    live_feed: LiveDataFeed,
+    example_lap,
+    drivers,
+    title: str,
+    driver_colors=None,
+    circuit_rotation: float = 0.0,
+    session_info: dict = None,
+    session=None,
+    ready_file: str = None,
+):
+    """Open a LiveRaceWindow and run the Arcade event loop."""
+    window = LiveRaceWindow(
+        live_feed=live_feed,
+        track_statuses=[],          # synced from feed each update
+        example_lap=example_lap,
+        drivers=drivers,
+        driver_colors=driver_colors or {},
+        title=title,
+        total_laps=None,
+        circuit_rotation=circuit_rotation,
+        visible_hud=True,
+        session_info=session_info,
+        session=session,
+        enable_telemetry=True,
+    )
+    if ready_file:
+        try:
+            with open(ready_file, "w") as f:
+                f.write("ready")
+        except Exception:
+            pass
+    arcade.run()
 
 
 def launch_insights_menu():


### PR DESCRIPTION
Adds a --live flag (and CLI menu option) that detects an active F1 session from the OpenF1 REST API and streams live car positions, telemetry, tyre stints, weather and race-control messages into the existing Arcade visualiser.

Key changes:
- src/live_f1_data.py: OpenF1 API client + LiveDataFeed background poller that builds frames in the same format as the replay engine.
- src/interfaces/live_race.py: LiveRaceWindow extending F1RaceReplayWindow. Always shows the latest frame; SPACE freezes for DVR-style review; LEFT arrow steps back through the buffer; pulsing LIVE badge in top-right corner.
- src/run_session.py: run_live_arcade_replay() helper.
- main.py: live_main() resolves the current session, loads the circuit layout from FastF1 (qualifying → race → practice fallback), prefetches initial data, then opens the live viewer.
- src/cli/race_selection.py: "Watch Live" shown as the first option.
- requirements.txt: add requests and scipy (the latter was already used but not listed).

Usage:
  python main.py --live          # direct
  python main.py --cli           # pick "Watch Live" from menu