### PR TITLE
Add --playback-speed CLI flag for controlling replay speed

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,11 +134,16 @@ if __name__ == "__main__":
     list_rounds(year)
   elif "--list-sprints" in sys.argv:
     list_sprints(year)
+
+  if "--playback-speed" in sys.argv:
+    speed_index = sys.argv.index("--playback-speed") + 1
+    playback_speed = float(sys.argv[speed_index])
   else:
-    playback_speed = 1
+    playback_speed = 1.0  # Default playback speed
+
 
   if "--viewer" in sys.argv:
-  
+    
     visible_hud = True
     if "--no-hud" in sys.argv:
       visible_hud = False


### PR DESCRIPTION
## Summary

Adds a `--playback-speed` CLI flag so users can set the initial replay speed from the command line.

Closes #36

## Problem

`playback_speed` was hardcoded to `1` in `main.py` with no way to control it via CLI. Users could only change playback speed interactively after the replay launched.

## Changes

- Added `--playback-speed` argument parsing in `main.py`, consistent with the existing `--year` and `--round` patterns
- Defaults to `1.0` if the flag is not provided

## Usage

```bash
python main.py --viewer --year 2024 --round 12 --playback-speed 2.0
python main.py --viewer --year 2024 --round 5 --playback-speed 0.5
```

> **Note:** Valid speed values are constrained by `PLAYBACK_SPEEDS` in `race_replay.py` (`[0.1, 0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]`). Values not in this list will fall back to `1.0` — this behaviour is inherited from the existing window logic and unchanged by this PR.