### PR TITLE
feat: add Race Control Feed insight window with synced FIA race messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,8 @@ def main(year=None, round_number=None, playback_speed=1, session_type='R', visib
       ready_file=ready_file,
       session_info=session_info,
       session=session,
-      enable_telemetry=True # This is now permanently enabled to support the telemetry insights menu if the user decides to use it
+      enable_telemetry=True,
+      race_control_messages=race_telemetry.get('race_control_messages', [])
     )
 
 if __name__ == "__main__":

--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -1,3 +1,4 @@
+import math
 import os
 import pickle
 import sys
@@ -677,6 +678,49 @@ def get_race_telemetry(session, session_type="R"):
             }
         )
 
+    # 4a. Parse race control messages (flags, penalties, SC/VSC, DRS, etc.)
+    formatted_rc_messages = []
+    rc_messages = getattr(session, "race_control_messages", None)
+
+    def _safe_str(val, as_int=False):
+        """Convert a value to string, returning '' for None/NaN."""
+        if val is None:
+            return ""
+        try:
+            if isinstance(val, float) and math.isnan(val):
+                return ""
+        except (TypeError, ValueError):
+            pass
+        if as_int:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val)
+        return str(val)
+
+    if rc_messages is not None and not rc_messages.empty:
+        for msg in rc_messages.to_dict("records"):
+            time_val = msg["Time"]
+            if hasattr(time_val, 'total_seconds'):
+                # Timedelta (session-relative) — same as track_status
+                seconds = time_val.total_seconds()
+            else:
+                # Timestamp (absolute) — subtract the data stream origin
+                seconds = (time_val - session.t0_date).total_seconds()
+            msg_time = seconds - global_t_min
+
+            if msg_time > 0.0:
+                formatted_rc_messages.append({
+                    "time": round(msg_time, 3),
+                    "category": _safe_str(msg.get("Category", "")),
+                    "message": _safe_str(msg.get("Message", "")),
+                    "flag": _safe_str(msg.get("Flag", "")),
+                    "scope": _safe_str(msg.get("Scope", "")),
+                    "sector": _safe_str(msg.get("Sector", ""), as_int=True),
+                    "racing_number": _safe_str(msg.get("RacingNumber", ""), as_int=True),
+                })
+        formatted_rc_messages.sort(key=lambda m: m["time"])
+
     # 4.1. Resample weather data onto the same timeline for playback
     weather_resampled = None
     weather_df = getattr(session, "weather_data", None)
@@ -840,6 +884,7 @@ def get_race_telemetry(session, session_type="R"):
             "frames": frames,
             "driver_colors": get_driver_colors(session),
             "track_statuses": formatted_track_statuses,
+            "race_control_messages": formatted_rc_messages,
             "total_laps": int(max_lap_number),
             "max_tyre_life": max_tyre_life_map,
         }, f, protocol=pickle.HIGHEST_PROTOCOL)
@@ -850,6 +895,7 @@ def get_race_telemetry(session, session_type="R"):
         "frames": frames,
         "driver_colors": get_driver_colors(session),
         "track_statuses": formatted_track_statuses,
+        "race_control_messages": formatted_rc_messages,
         "total_laps": int(max_lap_number),
         "max_tyre_life": max_tyre_life_map,
     }

--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -66,6 +66,13 @@ class InsightsMenu(QMainWindow):
                 ("Track Position Map", "Live driver positions plotted on a circular track map", self.launch_track_position),
             ]
         ))
+
+        content_layout.addWidget(self.create_category_section(
+            "Race Events",
+            [
+                ("Race Control Feed", "Live FIA flags, penalties, safety car and DRS status", self.launch_race_control_feed),
+            ]
+        ))
         
         content_layout.addStretch()
         
@@ -183,6 +190,13 @@ class InsightsMenu(QMainWindow):
         print("🚀 Launching: Track Position Map")
         from src.insights.track_position_window import TrackPositionWindow
         window = TrackPositionWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_race_control_feed(self):
+        print("🚀 Launching: Race Control Feed")
+        from src.insights.race_control_feed_window import RaceControlFeedWindow
+        window = RaceControlFeedWindow()
         window.show()
         self.opened_windows.append(window)
 

--- a/src/insights/race_control_feed_window.py
+++ b/src/insights/race_control_feed_window.py
@@ -1,0 +1,294 @@
+"""
+Race Control Feed insight window.
+
+Displays FIA race control messages (flags, penalties, safety car,
+DRS, investigations) as a scrolling feed synced to replay time.
+"""
+
+import sys
+import math
+from PySide6.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QLabel, QTextBrowser
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFont, QColor
+from src.gui.pit_wall_window import PitWallWindow
+
+
+# ── Colour palette (matches the app's existing dark theme) ────────────────
+_BG           = "#282828"
+_BG_DARKER    = "#1E1E1E"
+_BORDER       = "#3A3A3A"
+_TEXT_PRIMARY  = "#E0E0E0"
+_TEXT_DIMMED   = "#888888"
+_TEXT_TIME     = "#999999"
+
+# Category accent colours (used for the left-edge indicator bar)
+_CAT_COLOURS = {
+    "Flag":      "#FFD700",   # amber/gold
+    "SafetyCar": "#FF8C00",   # orange
+    "Drs":       "#00CED1",   # cyan
+    "Other":     "#666666",   # subtle grey
+    "CarEvent":  "#B0B0B0",   # light grey
+}
+
+# Flag-specific overrides for the accent colour
+_FLAG_COLOURS = {
+    "YELLOW":         "#FFD700",
+    "DOUBLE YELLOW":  "#FFD700",
+    "RED":            "#E74C3C",
+    "GREEN":          "#2ECC71",
+    "CHEQUERED":      "#F0F0F0",
+    "BLUE":           "#3498DB",
+    "BLACK AND WHITE":"#B0B0B0",
+    "BLACK AND ORANGE":"#FF8C00",
+    "CLEAR":          "#2ECC71",
+}
+
+
+def _format_time(seconds):
+    """Convert seconds to HH:MM:SS string."""
+    if seconds < 0:
+        seconds = 0
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    return f"{h:02}:{m:02}:{s:02}"
+
+
+def _accent_for_event(event):
+    """Return accent hex colour for a race control event."""
+    flag = event.get("flag", "")
+    category = event.get("category", "Other")
+
+    if flag and flag in _FLAG_COLOURS:
+        return _FLAG_COLOURS[flag]
+
+    return _CAT_COLOURS.get(category, _CAT_COLOURS["Other"])
+
+
+def _clean_sector(val):
+    """Return a clean sector string, or empty if NaN / empty."""
+    if not val:
+        return ""
+    try:
+        f = float(val)
+        if math.isnan(f):
+            return ""
+        return str(int(f))
+    except (ValueError, TypeError):
+        return str(val)
+
+
+# ── State labels ──────────────────────────────────────────────────────────
+_WAITING_TEXT = "Waiting for race control messages..."
+_NO_DATA_TEXT = (
+    "No race control data in cache.\n\n"
+    "Delete the .pkl file in computed_data/\n"
+    "and re-run the session to regenerate."
+)
+
+
+class RaceControlFeedWindow(PitWallWindow):
+    """Scrolling feed of FIA race control messages synced to the replay."""
+
+    def __init__(self):
+        self._seen_hashes = set()
+        self._state = "init"  # "init" | "waiting" | "no_data" | "active"
+        self._last_frame_index = -1
+        super().__init__()
+        self.setWindowTitle("Race Control Feed")
+        self.setGeometry(120, 120, 420, 620)
+
+    def setup_ui(self):
+        central = QWidget()
+        central.setStyleSheet(f"background: {_BG};")
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        # Header bar
+        header = QWidget()
+        header.setStyleSheet(
+            f"background: {_BG_DARKER}; border-bottom: 1px solid {_BORDER};"
+        )
+        header.setFixedHeight(56)
+        header_layout = QVBoxLayout(header)
+        header_layout.setContentsMargins(14, 8, 14, 8)
+        header_layout.setSpacing(2)
+
+        title = QLabel("RACE CONTROL")
+        title.setFont(QFont("Arial", 13, QFont.Bold))
+        title.setStyleSheet(f"color: {_TEXT_PRIMARY}; border: none;")
+        header_layout.addWidget(title)
+
+        self._status_line = QLabel("Waiting for data...")
+        self._status_line.setFont(QFont("Arial", 10))
+        self._status_line.setStyleSheet(f"color: {_TEXT_DIMMED}; border: none;")
+        header_layout.addWidget(self._status_line)
+
+        root.addWidget(header)
+
+        # Event list
+        self._text_browser = QTextBrowser()
+        self._text_browser.setStyleSheet(f"""
+            QTextBrowser {{
+                background: {_BG};
+                color: {_TEXT_PRIMARY};
+                border: none;
+                outline: none;
+            }}
+            QScrollBar:vertical {{
+                border: none;
+                background: {_BG};
+                width: 12px;
+                margin: 0px;
+            }}
+            QScrollBar::handle:vertical {{
+                background: {_BORDER};
+                min-height: 20px;
+                border-radius: 4px;
+                margin: 2px;
+            }}
+            QScrollBar::handle:vertical:hover {{
+                background: #555555;
+            }}
+            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
+                height: 0px;
+                border: none;
+                background: none;
+            }}
+            QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{
+                background: none;
+            }}
+        """)
+        self._text_browser.setOpenExternalLinks(False)
+        self._text_browser.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self._text_browser.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        root.addWidget(self._text_browser, stretch=1)
+
+        # State label (waiting / no-data messages)
+        self._state_label = QLabel(_WAITING_TEXT)
+        self._state_label.setFont(QFont("Arial", 11))
+        self._state_label.setStyleSheet(
+            f"color: {_TEXT_DIMMED}; padding: 32px; background: {_BG};"
+        )
+        self._state_label.setAlignment(Qt.AlignCenter)
+        self._state_label.setWordWrap(True)
+        root.addWidget(self._state_label)
+
+        # Start with list hidden and state label shown
+        self._text_browser.hide()
+
+    def _set_state(self, state):
+        """Transition between init/waiting/no_data/active states."""
+        if state == self._state:
+            return
+        self._state = state
+
+        if state == "active":
+            self._state_label.hide()
+            self._text_browser.show()
+        elif state == "waiting":
+            self._state_label.setText(_WAITING_TEXT)
+            self._state_label.show()
+            self._text_browser.hide()
+        elif state == "no_data":
+            self._state_label.setText(_NO_DATA_TEXT)
+            self._state_label.show()
+            self._text_browser.hide()
+
+    def on_telemetry_data(self, data):
+        # Update header status line
+        session_data = data.get("session_data", {})
+        if session_data:
+            time_str = session_data.get("time", "")
+            lap = session_data.get("lap", "")
+            total = session_data.get("total_laps", "")
+            lap_text = f"Lap {lap}/{total}" if total else f"Lap {lap}"
+            self._status_line.setText(f"{lap_text}  ·  {time_str}")
+            self._status_line.setStyleSheet(f"color: {_TEXT_DIMMED}; border: none;")
+
+        # Detect rewinds or restarts to flush the feed
+        frame_idx = data.get("frame_index", -1)
+        if frame_idx >= 0 and self._last_frame_index >= 0 and frame_idx < self._last_frame_index:
+            self._seen_hashes.clear()
+            self._text_browser.clear()
+            self._set_state("init")
+        self._last_frame_index = frame_idx
+
+        # Determine state from the has_rc_data flag (sent by the replay)
+        has_rc_data = data.get("has_rc_data")
+        if has_rc_data is not None and self._state in ("init", "waiting", "no_data"):
+            if has_rc_data:
+                self._set_state("waiting")
+            else:
+                self._set_state("no_data")
+
+        # Process race control events
+        events = data.get("race_control_events", [])
+        for event in events:
+            event_hash = f"{event['time']}|{event['message']}"
+            if event_hash in self._seen_hashes:
+                continue
+            self._seen_hashes.add(event_hash)
+
+            if self._state != "active":
+                self._set_state("active")
+
+            self._add_event_item(event)
+
+    def _add_event_item(self, event):
+        """Append a formatted event to the text browser."""
+        icon_color = _accent_for_event(event)
+        time_str = _format_time(event["time"])
+        message = event.get("message", "")
+        sector = _clean_sector(event.get("sector", ""))
+        
+        sector_html = f'<br><span style="color: {_TEXT_DIMMED}; font-size: 11px;">Sector {sector}</span>' if sector else ""
+        
+        # We use a reliable HTML table structure to render the color accent bar
+        # alongside the text content inside the QTextBrowser.
+        html = f"""
+        <table width="100%" cellspacing="0" cellpadding="8" style="background: {_BG};">
+            <tr>
+                <td width="3" style="background-color: {icon_color}; padding: 0;"></td>
+                <td width="85" style="border-bottom: 1px solid {_BORDER}; vertical-align: top; padding-left: 10px; white-space: nowrap;">
+                    <span style="color: {_TEXT_TIME}; font-family: Consolas; font-size: 12px;">{time_str}</span>
+                </td>
+                <td style="border-bottom: 1px solid {_BORDER}; vertical-align: top;">
+                    <span style="color: {_TEXT_PRIMARY}; font-family: Arial; font-size: 14px;">{message}</span>
+                    {sector_html}
+                </td>
+            </tr>
+        </table>
+        """
+        
+        self._text_browser.append(html)
+        
+        # Scroll to bottom
+        scrollbar = self._text_browser.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
+
+    def on_connection_status_changed(self, status):
+        if status == "Disconnected":
+            self._status_line.setText("Disconnected")
+            self._status_line.setStyleSheet(f"color: #E74C3C; border: none;")
+        elif status == "Connecting...":
+            self._status_line.setText("Connecting...")
+            self._status_line.setStyleSheet(f"color: #FF8C00; border: none;")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+def main():
+    app = QApplication(sys.argv)
+    app.setApplicationName("Race Control Feed")
+    window = RaceControlFeedWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -30,7 +30,8 @@ class F1RaceReplayWindow(arcade.Window):
     def __init__(self, frames, track_statuses, example_lap, drivers, title,
                  playback_speed=1.0, driver_colors=None, circuit_rotation=0.0,
                  left_ui_margin=340, right_ui_margin=260, total_laps=None, visible_hud=True,
-                 session_info=None, session=None, enable_telemetry=False):
+                 session_info=None, session=None, enable_telemetry=False,
+                 race_control_messages=None):
         # Set resizable to True so the user can adjust mid-sim
         super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, title, resizable=True)
         self.maximize()
@@ -51,6 +52,7 @@ class F1RaceReplayWindow(arcade.Window):
 
         self.frames = frames
         self.track_statuses = track_statuses
+        self.race_control_messages = race_control_messages or []
         self.n_frames = len(frames)
         self.drivers = list(drivers)
         self.playback_speed = PLAYBACK_SPEEDS[PLAYBACK_SPEEDS.index(playback_speed)] if playback_speed in PLAYBACK_SPEEDS else 1.0
@@ -243,13 +245,19 @@ class F1RaceReplayWindow(arcade.Window):
         if current_frame and "drivers" in current_frame:
             driver_progress = {}
             for code, pos in current_frame["drivers"].items():
-                x, y = pos["x"], pos["y"]
-                progress_m = self._project_to_reference(x, y)
+                x, y = pos.get("x", 0.0), pos.get("y", 0.0)
+                lap_raw = pos.get("lap", 1)
+                try:
+                    lap = int(lap_raw)
+                except (ValueError, TypeError):
+                    lap = 1
+                projected_m = self._project_to_reference(x, y)
+                progress_m = float((max(lap, 1) - 1) * self._ref_total_length + projected_m)
                 driver_progress[code] = progress_m
                 
             if driver_progress:
-                leader_code = max(driver_progress.keys(), key=lambda k: driver_progress[k])
-                leader_lap = current_frame["drivers"].get(leader_code, {}).get("lap", 1)
+                leader_code = max(driver_progress.keys(), key=lambda c: driver_progress[c])
+                leader_lap = current_frame["drivers"][leader_code].get("lap", 1)
         
         # Format time
         t = current_frame["t"] if current_frame else 0
@@ -258,11 +266,24 @@ class F1RaceReplayWindow(arcade.Window):
         seconds = int(t % 60)
         time_str = f"{hours:02}:{minutes:02}:{seconds:02}"
         
+        # Gather all race control events up to the current frame time.
+        # Sends the full history every broadcast so newly opened windows
+        # receive all past events immediately.  The list is small (30-80
+        # messages per race) and the window de-duplicates on its end.
+        rc_events = []
+        if current_frame and self.race_control_messages:
+            frame_time = current_frame["t"]
+            for msg in self.race_control_messages:
+                if msg["time"] <= frame_time:
+                    rc_events.append(msg)
+                else:
+                    break  # list is sorted, nothing further will match
+
         hex_driver_colors = {
             code: "#{:02X}{:02X}{:02X}".format(*rgb)
             for code, rgb in self.driver_colors.items()
         }
-        self.telemetry_stream.broadcast({
+        broadcast_payload = {
             "frame_index": int(self.frame_index),
             "frame": current_frame,
             "track_status": current_track_status,
@@ -271,13 +292,16 @@ class F1RaceReplayWindow(arcade.Window):
             "total_frames": self.n_frames,
             "circuit_length_m": self.circuit_length_m,
             "driver_colors": hex_driver_colors,
+            "has_rc_data": bool(self.race_control_messages),
+            "race_control_events": rc_events,
             "session_data": {
                 "time": time_str,
                 "lap": leader_lap,
                 "leader": leader_code,
                 "total_laps": self.total_laps
             }
-        })
+        }
+        self.telemetry_stream.broadcast(broadcast_payload)
 
     def _interpolate_points(self, xs, ys, interp_points=2000):
         t_old = np.linspace(0, 1, len(xs))

--- a/src/run_session.py
+++ b/src/run_session.py
@@ -9,7 +9,8 @@ from src.insights.telemetry_stream_viewer import main as telemetry_viewer_main
 
 def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
                       playback_speed=1.0, driver_colors=None, circuit_rotation=0.0, total_laps=None,
-                      visible_hud=True, ready_file=None, session_info=None, session=None, enable_telemetry=True):
+                      visible_hud=True, ready_file=None, session_info=None, session=None,
+                      enable_telemetry=True, race_control_messages=None):
     window = F1RaceReplayWindow(
         frames=frames,
         track_statuses=track_statuses,
@@ -23,7 +24,8 @@ def run_arcade_replay(frames, track_statuses, example_lap, drivers, title,
         visible_hud=visible_hud,
         session_info=session_info,
         session=session,
-        enable_telemetry=enable_telemetry
+        enable_telemetry=enable_telemetry,
+        race_control_messages=race_control_messages
     )
     # Signal readiness to parent process (if requested) after window created
     if ready_file:


### PR DESCRIPTION
Closes #277

## Summary

Adds a new **Race Control Feed** insight window that displays FIA race control messages (flags, penalties, safety car, DRS, investigations) as a scrolling feed synced to the replay timeline.

## Changes

### Data Pipeline (`src/f1_data.py`)
- Extract `session.race_control_messages` from FastF1
- Normalize timestamps (handles both Timedelta and Timestamp formats)
- Filter pre-race messages, clean NaN values in sector/racing_number fields
- Include in pickle cache for instant subsequent loads

### Broadcast System (`src/interfaces/race_replay.py`)
- Broadcast all events up to current frame time so newly opened windows receive full history
- Add `has_rc_data` flag for deterministic empty-state handling
- Sync leader lap calculation with main window (uses `_ref_total_length` with defensive int() casting)

### UI (`src/insights/race_control_feed_window.py`) [NEW]
- Dark-themed feed matching app aesthetic (#282828, Arial/Consolas)
- Color-coded accent bars by event type (flags, SC, DRS, penalties)
- HTML-based rendering via QTextBrowser for reliable text wrapping
- Auto-scrolling, content deduplication, rewind/restart detection
- Styled scrollbar matching the dark theme
- Graceful empty states: "Waiting..." vs cache regeneration instructions

### Integration
- `main.py` / `run_session.py`: Pass RC messages through the replay pipeline
- `insights_menu.py`: New "Race Events" category in the Insights Menu

## Design Decisions

- **Zero new dependencies** — uses existing FastF1 data
- **Backwards compatible** — `.get('race_control_messages', [])` handles old cache files gracefully
- **Data available 2018+** — all sessions from 2018 onwards have FIA race control messages

## Testing

- Syntax verified across all 6 files
- Verified with 2026 Australian & Chinese GP (Rounds 1 & 2) — messages render correctly, timestamps sync with replay, rewind/restart flushes and rebuilds feed
- All modified files pass `py_compile`

## Screenshots

#### Added "Race Events" Section in Insights Menu
<img width="301" height="627" alt="Screenshot 2026-04-17 at 10 21 13" src="https://github.com/user-attachments/assets/2bbe6d83-44d4-4c14-96be-90ec285da61e" />

#### Race Control Feed Window
<img width="1468" height="918" alt="Screenshot 2026-04-17 at 10 25 30" src="https://github.com/user-attachments/assets/9f9c7e2b-391f-4888-b775-0c0764de8df2" />

#### How it looks visually for a Race

https://github.com/user-attachments/assets/91131bc5-c244-4a44-8599-7fa2c424de6b

