### PR TITLE
Add strategy insight windows for virtual position, undercut analysis, and DRS-train detection

### DIFF
--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -68,6 +68,15 @@ class InsightsMenu(QMainWindow):
         ))
 
         content_layout.addWidget(self.create_category_section(
+            "Strategy",
+            [
+                ("Virtual Position", "Estimate pit rejoin position and clean-air risk", self.launch_virtual_position),
+                ("Undercut / Overcut", "Compare two cars for stop-first versus stay-out calls", self.launch_undercut_overcut),
+                ("DRS Train / Traffic", "Detect trains, local traffic, and attack blockers", self.launch_drs_traffic),
+            ]
+        ))
+
+        content_layout.addWidget(self.create_category_section(
             "Race Events",
             [
                 ("Race Control Feed", "Live FIA flags, penalties, safety car and DRS status", self.launch_race_control_feed),
@@ -197,6 +206,27 @@ class InsightsMenu(QMainWindow):
         print("🚀 Launching: Race Control Feed")
         from src.insights.race_control_feed_window import RaceControlFeedWindow
         window = RaceControlFeedWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_virtual_position(self):
+        print("Launching: Virtual Position")
+        from src.insights.virtual_position_window import VirtualPositionWindow
+        window = VirtualPositionWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_undercut_overcut(self):
+        print("Launching: Undercut / Overcut")
+        from src.insights.undercut_overcut_window import UndercutOvercutWindow
+        window = UndercutOvercutWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_drs_traffic(self):
+        print("Launching: DRS Train / Traffic")
+        from src.insights.drs_traffic_window import DrsTrafficWindow
+        window = DrsTrafficWindow()
         window.show()
         self.opened_windows.append(window)
 

--- a/src/insights/drs_traffic_window.py
+++ b/src/insights/drs_traffic_window.py
@@ -1,0 +1,139 @@
+import sys
+from collections import deque
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.gui.pit_wall_window import PitWallWindow
+from src.insights.strategy_utils import (
+    build_driver_snapshots,
+    detect_drs_trains,
+    drs_state,
+    estimate_gap_seconds,
+)
+
+
+class DrsTrafficWindow(PitWallWindow):
+    def __init__(self):
+        self._known_drivers = []
+        super().__init__()
+        self.setWindowTitle("F1 Race Replay - DRS Train / Traffic")
+        self.setMinimumSize(780, 620)
+
+    def setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+
+        controls = QGroupBox("Traffic Detector")
+        form = QFormLayout(controls)
+        self.driver_combo = QComboBox()
+        self.threshold_spin = QDoubleSpinBox()
+        self.threshold_spin.setRange(0.5, 3.0)
+        self.threshold_spin.setDecimals(1)
+        self.threshold_spin.setSingleStep(0.1)
+        self.threshold_spin.setValue(1.2)
+        form.addRow("Focus driver", self.driver_combo)
+        form.addRow("Train threshold (s)", self.threshold_spin)
+        root.addWidget(controls)
+
+        self.summary = QLabel("Waiting for telemetry...")
+        self.summary.setWordWrap(True)
+        root.addWidget(self.summary)
+
+        self.table = QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels(["Lead", "Cars", "Train", "Avg Gap", "DRS Followers"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        root.addWidget(self.table, stretch=1)
+
+    def on_telemetry_data(self, data):
+        frame = data.get("frame")
+        if not frame:
+            return
+
+        snapshots = build_driver_snapshots(frame)
+        if not snapshots:
+            return
+
+        codes = [snap.code for snap in snapshots]
+        if codes != self._known_drivers:
+            current = self.driver_combo.currentText()
+            self.driver_combo.blockSignals(True)
+            self.driver_combo.clear()
+            self.driver_combo.addItems(codes)
+            if current in codes:
+                self.driver_combo.setCurrentText(current)
+            self.driver_combo.blockSignals(False)
+            self._known_drivers = codes
+
+        trains = detect_drs_trains(snapshots, self.threshold_spin.value())
+        self.table.setRowCount(len(trains))
+        for row, train in enumerate(trains):
+            values = [
+                train["lead"],
+                str(train["length"]),
+                " -> ".join(train["cars"]),
+                f"{train['avg_gap_s']:.2f}s",
+                str(train["active_drs_followers"]),
+            ]
+            for col, value in enumerate(values):
+                self.table.setItem(row, col, QTableWidgetItem(value))
+
+        focus = self.driver_combo.currentText() or codes[0]
+        focus_snap = next((snap for snap in snapshots if snap.code == focus), None)
+        focus_text = f"{focus}: no live data"
+        if focus_snap:
+            idx = snapshots.index(focus_snap)
+            ahead_gap = None
+            behind_gap = None
+            if idx > 0:
+                ahead_gap = estimate_gap_seconds(snapshots[idx - 1], focus_snap)
+            if idx < len(snapshots) - 1:
+                behind_gap = estimate_gap_seconds(focus_snap, snapshots[idx + 1])
+
+            in_train = next((train for train in trains if focus in train["cars"]), None)
+            if in_train:
+                focus_text = (
+                    f"{focus} is in a {in_train['length']}-car train led by {in_train['lead']} "
+                    f"with avg gap {in_train['avg_gap_s']:.2f}s. "
+                    f"DRS state: {drs_state(focus_snap.drs)}. "
+                    f"Gaps: ahead {_fmt_gap(ahead_gap)}, behind {_fmt_gap(behind_gap)}."
+                )
+            else:
+                traffic_tag = "traffic" if (ahead_gap is not None and ahead_gap < 2.0) or (behind_gap is not None and behind_gap < 2.0) else "clear air"
+                focus_text = (
+                    f"{focus} is not currently in a detected DRS train. "
+                    f"DRS state: {drs_state(focus_snap.drs)}. "
+                    f"Gaps: ahead {_fmt_gap(ahead_gap)}, behind {_fmt_gap(behind_gap)}. "
+                    f"Local picture: {traffic_tag}."
+                )
+
+        self.summary.setText(
+            f"Detected trains: {len(trains)}\n{focus_text}"
+        )
+
+
+def _fmt_gap(value):
+    return "-" if value is None else f"{value:.1f}s"
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setApplicationName("DRS Train / Traffic")
+    window = DrsTrafficWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/insights/strategy_utils.py
+++ b/src/insights/strategy_utils.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Iterable, List, Optional, Tuple
+
+
+@dataclass
+class DriverSnapshot:
+    code: str
+    position: int
+    progress_m: float
+    speed_kph: float
+    tyre: object
+    tyre_life: float
+    lap: int
+    drs: int
+
+
+def build_driver_snapshots(frame: dict) -> List[DriverSnapshot]:
+    drivers = frame.get("drivers", {}) if frame else {}
+    snapshots: List[DriverSnapshot] = []
+
+    for code, info in drivers.items():
+        snapshots.append(
+            DriverSnapshot(
+                code=code,
+                position=int(info.get("position", 999)),
+                progress_m=float(info.get("dist", 0.0)),
+                speed_kph=float(info.get("speed", 0.0)),
+                tyre=info.get("tyre", "?"),
+                tyre_life=float(info.get("tyre_life", 0.0)),
+                lap=int(info.get("lap", 0) or 0),
+                drs=int(info.get("drs", 0) or 0),
+            )
+        )
+
+    snapshots.sort(key=lambda s: (s.position, -s.progress_m, s.code))
+    return snapshots
+
+
+def speed_mps(speed_kph: float) -> float:
+    return max(1.0, float(speed_kph) / 3.6)
+
+
+def drs_state(drs_value: int) -> str:
+    if drs_value in (10, 12, 14):
+        return "ON"
+    if drs_value == 8:
+        return "AVAIL"
+    return "OFF"
+
+
+def estimate_gap_seconds(front: DriverSnapshot, back: DriverSnapshot) -> float:
+    gap_m = max(0.0, front.progress_m - back.progress_m)
+    ref_speed = max(speed_mps(front.speed_kph), speed_mps(back.speed_kph))
+    return gap_m / ref_speed
+
+
+def recent_progress_rate(history: Deque[Tuple[float, float]], window_s: float) -> Optional[float]:
+    if len(history) < 2:
+        return None
+
+    t_end = history[-1][0]
+    eligible = [sample for sample in history if t_end - sample[0] <= window_s]
+    if len(eligible) < 2:
+        eligible = list(history)[-2:]
+
+    t0, p0 = eligible[0]
+    t1, p1 = eligible[-1]
+    dt = t1 - t0
+    if dt <= 0:
+        return None
+
+    return max(0.0, (p1 - p0) / dt)
+
+
+def equivalent_lap_time(progress_rate_mps: Optional[float], circuit_length_m: Optional[float]) -> Optional[float]:
+    if not progress_rate_mps or not circuit_length_m or progress_rate_mps <= 0:
+        return None
+    return circuit_length_m / progress_rate_mps
+
+
+def find_virtual_rejoin(
+    snapshots: Iterable[DriverSnapshot],
+    selected_code: str,
+    pit_loss_s: float,
+    reference_speed_mps: float,
+) -> Optional[dict]:
+    ordered = list(snapshots)
+    selected = next((snap for snap in ordered if snap.code == selected_code), None)
+    if not selected:
+        return None
+
+    projected_progress = selected.progress_m - max(0.0, pit_loss_s) * max(1.0, reference_speed_mps)
+
+    ranking: List[Tuple[str, float]] = []
+    for snap in ordered:
+        progress = projected_progress if snap.code == selected_code else snap.progress_m
+        ranking.append((snap.code, progress))
+
+    ranking.sort(key=lambda item: item[1], reverse=True)
+    codes = [code for code, _ in ranking]
+    projected_position = codes.index(selected_code) + 1
+
+    ahead_code = codes[projected_position - 2] if projected_position > 1 else None
+    behind_code = codes[projected_position] if projected_position < len(codes) else None
+
+    ahead_gap_s = None
+    behind_gap_s = None
+    if ahead_code:
+        ahead_progress = dict(ranking)[ahead_code]
+        ahead_gap_s = max(0.0, ahead_progress - projected_progress) / max(1.0, reference_speed_mps)
+    if behind_code:
+        behind_progress = dict(ranking)[behind_code]
+        behind_gap_s = max(0.0, projected_progress - behind_progress) / max(1.0, reference_speed_mps)
+
+    min_gap = min(
+        gap for gap in (ahead_gap_s, behind_gap_s) if gap is not None
+    ) if ahead_gap_s is not None or behind_gap_s is not None else None
+
+    if min_gap is None:
+        traffic_risk = "Clear"
+    elif min_gap < 1.0:
+        traffic_risk = "Heavy traffic"
+    elif min_gap < 2.0:
+        traffic_risk = "Moderate traffic"
+    else:
+        traffic_risk = "Clean air"
+
+    return {
+        "projected_position": projected_position,
+        "ahead_code": ahead_code,
+        "behind_code": behind_code,
+        "ahead_gap_s": ahead_gap_s,
+        "behind_gap_s": behind_gap_s,
+        "traffic_risk": traffic_risk,
+        "projected_progress": projected_progress,
+        "ranking": ranking,
+    }
+
+
+def detect_drs_trains(
+    snapshots: Iterable[DriverSnapshot],
+    gap_threshold_s: float = 1.2,
+) -> List[dict]:
+    ordered = list(snapshots)
+    trains: List[dict] = []
+    current_group: List[DriverSnapshot] = []
+    current_gaps: List[float] = []
+
+    for idx, snap in enumerate(ordered):
+        if idx == 0:
+            current_group = [snap]
+            current_gaps = []
+            continue
+
+        front = ordered[idx - 1]
+        gap_s = estimate_gap_seconds(front, snap)
+        drs_hint = drs_state(snap.drs) in ("ON", "AVAIL")
+
+        if gap_s <= gap_threshold_s or drs_hint:
+            current_group.append(snap)
+            current_gaps.append(gap_s)
+        else:
+            if len(current_group) >= 3:
+                trains.append(_format_train(current_group, current_gaps))
+            current_group = [snap]
+            current_gaps = []
+
+    if len(current_group) >= 3:
+        trains.append(_format_train(current_group, current_gaps))
+
+    return trains
+
+
+def _format_train(group: List[DriverSnapshot], gaps: List[float]) -> dict:
+    avg_gap = sum(gaps) / len(gaps) if gaps else 0.0
+    active_drs = sum(1 for snap in group[1:] if drs_state(snap.drs) in ("ON", "AVAIL"))
+    return {
+        "lead": group[0].code,
+        "tail": group[-1].code,
+        "cars": [snap.code for snap in group],
+        "length": len(group),
+        "avg_gap_s": avg_gap,
+        "active_drs_followers": active_drs,
+    }
+
+
+def classify_strategy_signal(
+    gap_s: Optional[float],
+    pace_delta_s_per_lap: Optional[float],
+    tyre_life_delta: Optional[float],
+    traffic_risk: str,
+) -> Tuple[str, str]:
+    if gap_s is None or pace_delta_s_per_lap is None or tyre_life_delta is None:
+        return ("Insufficient data", "Need more replay history to score the move.")
+
+    undercut_score = 0
+    overcut_score = 0
+
+    if gap_s <= 3.0:
+        undercut_score += 2
+    elif gap_s <= 5.0:
+        undercut_score += 1
+
+    if pace_delta_s_per_lap < -0.3:
+        undercut_score += 2
+    elif pace_delta_s_per_lap < 0:
+        undercut_score += 1
+    elif pace_delta_s_per_lap > 0.3:
+        overcut_score += 2
+    elif pace_delta_s_per_lap > 0:
+        overcut_score += 1
+
+    if tyre_life_delta > 3:
+        undercut_score += 2
+    elif tyre_life_delta > 0:
+        undercut_score += 1
+    elif tyre_life_delta < -3:
+        overcut_score += 1
+
+    if traffic_risk == "Clean air":
+        undercut_score += 1
+    elif traffic_risk == "Heavy traffic":
+        overcut_score += 2
+    elif traffic_risk == "Moderate traffic":
+        overcut_score += 1
+
+    if undercut_score >= overcut_score + 2:
+        return ("Undercut favored", "Gap, tyre age, and projected rejoin traffic support stopping first.")
+    if overcut_score >= undercut_score + 2:
+        return ("Overcut possible", "Current pace or traffic risk argues for staying out longer.")
+    return ("Marginal", "The gap is live, but the traffic and pace picture is not one-sided.")

--- a/src/insights/undercut_overcut_window.py
+++ b/src/insights/undercut_overcut_window.py
@@ -1,0 +1,196 @@
+import sys
+from collections import deque
+
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.gui.pit_wall_window import PitWallWindow
+from src.insights.strategy_utils import (
+    build_driver_snapshots,
+    classify_strategy_signal,
+    equivalent_lap_time,
+    estimate_gap_seconds,
+    find_virtual_rejoin,
+    recent_progress_rate,
+)
+
+
+class UndercutOvercutWindow(PitWallWindow):
+    def __init__(self):
+        self._known_drivers = []
+        self._history = {}
+        self._circuit_length_m = None
+        super().__init__()
+        self.setWindowTitle("F1 Race Replay - Undercut / Overcut")
+        self.setMinimumSize(760, 620)
+
+    def setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+
+        controls = QGroupBox("Comparison")
+        form = QFormLayout(controls)
+        self.attacker_combo = QComboBox()
+        self.defender_combo = QComboBox()
+        self.pit_loss_spin = QDoubleSpinBox()
+        self.pit_loss_spin.setRange(10.0, 40.0)
+        self.pit_loss_spin.setDecimals(1)
+        self.pit_loss_spin.setSingleStep(0.5)
+        self.pit_loss_spin.setValue(22.0)
+        form.addRow("Car A", self.attacker_combo)
+        form.addRow("Car B", self.defender_combo)
+        form.addRow("Pit loss (s)", self.pit_loss_spin)
+        root.addWidget(controls)
+
+        self.headline = QLabel("Waiting for telemetry...")
+        self.headline.setFont(QFont("Arial", 12, QFont.Bold))
+        self.headline.setWordWrap(True)
+        root.addWidget(self.headline)
+
+        self.detail_text = QTextEdit()
+        self.detail_text.setReadOnly(True)
+        self.detail_text.setFont(QFont("Courier", 10))
+        root.addWidget(self.detail_text, stretch=1)
+
+    def on_telemetry_data(self, data):
+        frame = data.get("frame")
+        if not frame:
+            return
+
+        if data.get("circuit_length_m"):
+            self._circuit_length_m = float(data["circuit_length_m"])
+
+        snapshots = build_driver_snapshots(frame)
+        if not snapshots:
+            return
+
+        session_t = float(frame.get("t", 0.0))
+        for snap in snapshots:
+            history = self._history.setdefault(snap.code, deque(maxlen=180))
+            history.append((session_t, snap.progress_m))
+
+        codes = [snap.code for snap in snapshots]
+        if codes != self._known_drivers:
+            attacker = self.attacker_combo.currentText()
+            defender = self.defender_combo.currentText()
+            for combo, current in ((self.attacker_combo, attacker), (self.defender_combo, defender)):
+                combo.blockSignals(True)
+                combo.clear()
+                combo.addItems(codes)
+                if current in codes:
+                    combo.setCurrentText(current)
+                combo.blockSignals(False)
+            if len(codes) > 1 and not self.defender_combo.currentText():
+                self.defender_combo.setCurrentIndex(1)
+            self._known_drivers = codes
+
+        code_a = self.attacker_combo.currentText() or codes[0]
+        code_b = self.defender_combo.currentText() or (codes[1] if len(codes) > 1 else codes[0])
+        if code_a == code_b:
+            self.headline.setText("Select two different drivers to compare.")
+            return
+
+        snap_a = next((snap for snap in snapshots if snap.code == code_a), None)
+        snap_b = next((snap for snap in snapshots if snap.code == code_b), None)
+        if not snap_a or not snap_b:
+            return
+
+        if snap_a.progress_m >= snap_b.progress_m:
+            front, back = snap_a, snap_b
+        else:
+            front, back = snap_b, snap_a
+
+        gap_s = estimate_gap_seconds(front, back)
+        rate_a = recent_progress_rate(self._history.get(code_a, deque()), 20.0)
+        rate_b = recent_progress_rate(self._history.get(code_b, deque()), 20.0)
+        lap_time_a = equivalent_lap_time(rate_a, self._circuit_length_m)
+        lap_time_b = equivalent_lap_time(rate_b, self._circuit_length_m)
+        pace_delta = None
+        if lap_time_a is not None and lap_time_b is not None:
+            pace_delta = lap_time_a - lap_time_b
+
+        # Positive tyre_life_delta means back car is on older tyres than front car.
+        tyre_life_delta = back.tyre_life - front.tyre_life
+
+        field_rates = [rate for rate in (recent_progress_rate(self._history.get(s.code, deque()), 15.0) for s in snapshots) if rate]
+        reference_speed = sum(field_rates) / len(field_rates) if field_rates else 55.0
+        projection = find_virtual_rejoin(
+            snapshots,
+            back.code,
+            self.pit_loss_spin.value(),
+            reference_speed,
+        )
+        traffic_risk = projection["traffic_risk"] if projection else "Unknown"
+
+        back_pace_delta = None
+        if pace_delta is not None:
+            if back.code == code_a:
+                back_pace_delta = pace_delta
+            else:
+                back_pace_delta = -pace_delta
+
+        signal, rationale = classify_strategy_signal(
+            gap_s=gap_s,
+            pace_delta_s_per_lap=back_pace_delta,
+            tyre_life_delta=tyre_life_delta,
+            traffic_risk=traffic_risk,
+        )
+
+        self.headline.setText(
+            f"Front: {front.code}  |  Chasing: {back.code}  |  Call: {signal}"
+        )
+
+        details = [
+            f"Current gap: {gap_s:.2f}s",
+            f"{code_a} current pos: P{snap_a.position}  tyre age: {snap_a.tyre_life:.0f}  speed: {snap_a.speed_kph:.0f} km/h",
+            f"{code_b} current pos: P{snap_b.position}  tyre age: {snap_b.tyre_life:.0f}  speed: {snap_b.speed_kph:.0f} km/h",
+            "",
+            f"Recent pace delta ({code_a} - {code_b}): {_fmt_optional_delta(pace_delta)} per lap",
+            f"Tyre age delta (chasing - front): {tyre_life_delta:+.0f} laps",
+            f"Projected rejoin for {back.code} if pitting now: "
+            f"P{projection['projected_position']}  |  traffic: {traffic_risk}" if projection else
+            "Projected rejoin: unavailable",
+            "",
+            f"Reading: {rationale}",
+        ]
+
+        if projection:
+            details.extend(
+                [
+                    f"Ahead at rejoin: {projection['ahead_code'] or '-'} ({_fmt_gap(projection['ahead_gap_s'])})",
+                    f"Behind at rejoin: {projection['behind_code'] or '-'} ({_fmt_gap(projection['behind_gap_s'])})",
+                ]
+            )
+
+        self.detail_text.setText("\n".join(details))
+
+
+def _fmt_optional_delta(value):
+    return "n/a" if value is None else f"{value:+.2f}s"
+
+
+def _fmt_gap(value):
+    return "-" if value is None else f"{value:.1f}s"
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setApplicationName("Undercut / Overcut")
+    window = UndercutOvercutWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/insights/virtual_position_window.py
+++ b/src/insights/virtual_position_window.py
@@ -1,0 +1,165 @@
+import sys
+from collections import deque
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.gui.pit_wall_window import PitWallWindow
+from src.insights.strategy_utils import (
+    build_driver_snapshots,
+    find_virtual_rejoin,
+    recent_progress_rate,
+)
+
+
+class VirtualPositionWindow(PitWallWindow):
+    def __init__(self):
+        self._known_drivers = []
+        self._history = {}
+        super().__init__()
+        self.setWindowTitle("F1 Race Replay - Virtual Position")
+        self.setMinimumSize(760, 560)
+
+    def setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+
+        controls = QGroupBox("Pit Rejoin Estimator")
+        controls_layout = QFormLayout(controls)
+
+        self.driver_combo = QComboBox()
+        self.driver_combo.setMinimumWidth(120)
+        self.pit_loss_spin = QDoubleSpinBox()
+        self.pit_loss_spin.setRange(10.0, 40.0)
+        self.pit_loss_spin.setDecimals(1)
+        self.pit_loss_spin.setSingleStep(0.5)
+        self.pit_loss_spin.setValue(22.0)
+
+        self.ref_speed_label = QLabel("Reference speed: -")
+
+        controls_layout.addRow("Driver", self.driver_combo)
+        controls_layout.addRow("Pit loss (s)", self.pit_loss_spin)
+        controls_layout.addRow("Field reference", self.ref_speed_label)
+        root.addWidget(controls)
+
+        summary = QGroupBox("Projection")
+        summary_layout = QVBoxLayout(summary)
+        self.summary_label = QLabel("Waiting for telemetry...")
+        self.summary_label.setWordWrap(True)
+        self.summary_label.setFont(QFont("Arial", 11))
+        summary_layout.addWidget(self.summary_label)
+        root.addWidget(summary)
+
+        self.table = QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["Proj P", "Driver", "Gap Ahead", "Gap Behind"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        root.addWidget(self.table, stretch=1)
+
+    def on_telemetry_data(self, data):
+        frame = data.get("frame")
+        if not frame:
+            return
+
+        snapshots = build_driver_snapshots(frame)
+        if not snapshots:
+            return
+
+        session_t = float(frame.get("t", 0.0))
+        for snap in snapshots:
+            history = self._history.setdefault(snap.code, deque(maxlen=180))
+            history.append((session_t, snap.progress_m))
+
+        current_codes = [snap.code for snap in snapshots]
+        if current_codes != self._known_drivers:
+            current = self.driver_combo.currentText()
+            self.driver_combo.blockSignals(True)
+            self.driver_combo.clear()
+            self.driver_combo.addItems(current_codes)
+            if current in current_codes:
+                self.driver_combo.setCurrentText(current)
+            self.driver_combo.blockSignals(False)
+            self._known_drivers = current_codes
+
+        selected = self.driver_combo.currentText() or current_codes[0]
+        speeds = []
+        for snap in snapshots:
+            rate = recent_progress_rate(self._history.get(snap.code, deque()), 15.0)
+            if rate:
+                speeds.append(rate)
+        reference_speed = sum(speeds) / len(speeds) if speeds else 55.0
+        self.ref_speed_label.setText(f"Reference speed: {reference_speed * 3.6:.0f} km/h")
+
+        projection = find_virtual_rejoin(
+            snapshots,
+            selected,
+            self.pit_loss_spin.value(),
+            reference_speed,
+        )
+        if not projection:
+            return
+
+        ahead_gap = _fmt_gap(projection["ahead_gap_s"])
+        behind_gap = _fmt_gap(projection["behind_gap_s"])
+        self.summary_label.setText(
+            f"{selected} would rejoin P{projection['projected_position']}.\n"
+            f"Ahead: {projection['ahead_code'] or '-'} ({ahead_gap})\n"
+            f"Behind: {projection['behind_code'] or '-'} ({behind_gap})\n"
+            f"Traffic risk: {projection['traffic_risk']}"
+        )
+
+        self.table.setRowCount(len(projection["ranking"]))
+        rank_map = {code: idx + 1 for idx, (code, _) in enumerate(projection["ranking"])}
+        ranking_progress = dict(projection["ranking"])
+        for row, snap in enumerate(snapshots):
+            proj_pos = rank_map[snap.code]
+            proj_progress = ranking_progress[snap.code]
+            ahead_code = projection["ranking"][proj_pos - 2][0] if proj_pos > 1 else None
+            behind_code = projection["ranking"][proj_pos][0] if proj_pos < len(projection["ranking"]) else None
+            ahead_gap = "-"
+            behind_gap = "-"
+            if ahead_code:
+                ahead_gap = _fmt_gap((ranking_progress[ahead_code] - proj_progress) / max(1.0, reference_speed))
+            if behind_code:
+                behind_gap = _fmt_gap((proj_progress - ranking_progress[behind_code]) / max(1.0, reference_speed))
+
+            items = [
+                QTableWidgetItem(str(proj_pos)),
+                QTableWidgetItem(snap.code),
+                QTableWidgetItem(ahead_gap),
+                QTableWidgetItem(behind_gap),
+            ]
+            if snap.code == selected:
+                for item in items:
+                    item.setBackground(Qt.darkYellow)
+            for col, item in enumerate(items):
+                self.table.setItem(row, col, item)
+
+
+def _fmt_gap(value):
+    return "-" if value is None else f"{value:.1f}s"
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setApplicationName("Virtual Position")
+    window = VirtualPositionWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds three new strategy-focused insight windows to the replay tool:

- Virtual Position
- Undercut / Overcut
- DRS Train / Traffic

It also adds shared analysis helpers for strategy views and wires the new windows into the Insights menu.

## New Windows

### Virtual Position
Estimates where a selected driver would rejoin after a pit stop using a configurable pit-loss assumption and a field reference speed.

### Undercut / Overcut
Compares two drivers using current gap, tyre age, recent pace trend, and projected rejoin traffic to support stop-first vs stay-out analysis.

### DRS Train / Traffic
Detects multi-car trains, highlights local traffic, and surfaces whether a selected driver is trapped in a DRS queue.

## Notes

These are heuristic strategy tools built from the existing telemetry stream payload and do not require new upstream data sources.