### PR TITLE
feat: add Lap Time Evolution chart with full race strategy analysis

### DIFF
--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -73,6 +73,13 @@ class InsightsMenu(QMainWindow):
                 ("Race Control Feed", "Live FIA flags, penalties, safety car and DRS status", self.launch_race_control_feed),
             ]
         ))
+
+        content_layout.addWidget(self.create_category_section(
+            "Race Analysis",
+            [
+                ("Lap Time Evolution", "Lap times for all drivers across the race", self.launch_lap_time_chart),
+            ]
+        ))
         
         content_layout.addStretch()
         
@@ -197,6 +204,13 @@ class InsightsMenu(QMainWindow):
         print("🚀 Launching: Race Control Feed")
         from src.insights.race_control_feed_window import RaceControlFeedWindow
         window = RaceControlFeedWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_lap_time_chart(self):
+        print("🚀 Launching: Lap Time Evolution")
+        from src.insights.lap_time_chart_window import LapTimeChartWindow
+        window = LapTimeChartWindow()
         window.show()
         self.opened_windows.append(window)
 

--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -78,7 +78,7 @@ class InsightsMenu(QMainWindow):
         content_layout.addWidget(self.create_category_section(
             "Race Analysis",
             [
-                ("Lap Time Evolution", "Lap times for all drivers across the race", self.launch_lap_time_chart),
+                ("Lap Time & Gap Evolution", "Lap time and gap trends per driver", self.launch_lap_time_chart),
             ]
         ))
         
@@ -209,7 +209,7 @@ class InsightsMenu(QMainWindow):
         self.opened_windows.append(window)
 
     def launch_lap_time_chart(self):
-        print("🚀 Launching: Lap Time Evolution")
+        print("🚀 Launching: Lap Time & Gap Evolution")
         from src.insights.lap_time_chart_window import LapTimeChartWindow
         window = LapTimeChartWindow()
         window.show()
@@ -253,8 +253,8 @@ class InsightsMenu(QMainWindow):
         self.show_placeholder_message("Sector Times")
     
     def launch_lap_evolution(self):
-        print("🚀 Launching: Lap Time Evolution")
-        self.show_placeholder_message("Lap Time Evolution")
+        print("🚀 Launching: Lap Time & Gap Evolution")
+        self.show_placeholder_message("Lap Time & Gap Evolution")
     
     def launch_top_speed(self):
         print("🚀 Launching: Top Speed Tracker")

--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -74,6 +74,13 @@ class InsightsMenu(QMainWindow):
                 ("Race Control Feed", "Live FIA flags, penalties, safety car and DRS status", self.launch_race_control_feed),
             ]
         ))
+
+        content_layout.addWidget(self.create_category_section(
+            "Race Analysis",
+            [
+                ("Lap Time Evolution", "Lap times for all drivers across the race", self.launch_lap_time_chart),
+            ]
+        ))
         
         content_layout.addStretch()
         
@@ -198,6 +205,13 @@ class InsightsMenu(QMainWindow):
         print("🚀 Launching: Race Control Feed")
         from src.insights.race_control_feed_window import RaceControlFeedWindow
         window = RaceControlFeedWindow()
+        window.show()
+        self.opened_windows.append(window)
+
+    def launch_lap_time_chart(self):
+        print("🚀 Launching: Lap Time Evolution")
+        from src.insights.lap_time_chart_window import LapTimeChartWindow
+        window = LapTimeChartWindow()
         window.show()
         self.opened_windows.append(window)
 

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -1,0 +1,1892 @@
+"""
+Lap Time Evolution Chart.
+
+Plots each driver's lap time across the race, updating live as the
+replay progresses.  Features include:
+
+- Tyre compound markers (circle/square/triangle/diamond/star)
+- Pit stop in/out lap separation
+- Safety Car and VSC shaded zones
+- 3-lap rolling pace trend line
+- Interactive crosshair tooltip on hover
+- Pit stop vertical markers with tyre change annotations
+- Click-to-isolate legend interaction
+- Gap-to-leader Y-axis mode toggle
+
+Lap times are pre-computed by the replay server from the full frame
+data, so they are deterministic regardless of playback speed.
+"""
+
+import sys
+from collections import defaultdict
+
+import numpy as np
+import matplotlib
+matplotlib.use("QtAgg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+
+from PySide6.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QComboBox, QPushButton, QCheckBox, QFrame, QDoubleSpinBox,
+    QDialog, QFormLayout, QDialogButtonBox
+)
+from PySide6.QtGui import QFont, QFontMetrics
+from PySide6.QtCore import Qt, QEvent
+from src.gui.pit_wall_window import PitWallWindow
+from src.lib.tyres import get_tyre_compound_int, get_tyre_compound_str
+
+# Colour palette
+_BG = "#282828"
+_GRID = "#3A3A3A"
+_TEXT = "#E0E0E0"
+_TEXT_DIM = "#888888"
+_DEFAULT_COLOUR = "#666666"
+
+# Safety Car / VSC zone colours
+_SC_COLOUR = "#FFD700"     # gold
+_VSC_COLOUR = "#FF8C00"    # dark orange
+_RED_FLAG_COLOUR = "#FF2020"
+
+# Tyre compound → marker shape
+_TYRE_MARKERS = {
+    get_tyre_compound_int("SOFT"):         "o",
+    get_tyre_compound_int("MEDIUM"):       "s",
+    get_tyre_compound_int("HARD"):         "^",
+    get_tyre_compound_int("INTERMEDIATE"): "D",
+    get_tyre_compound_int("WET"):          "*",
+}
+_DEFAULT_MARKER = "o"
+
+# Tyre compound → colour for stint shading
+_TYRE_COLOURS = {
+    get_tyre_compound_int("SOFT"):         "#FF3333",
+    get_tyre_compound_int("MEDIUM"):       "#FFD700",
+    get_tyre_compound_int("HARD"):         "#FFFFFF",
+    get_tyre_compound_int("INTERMEDIATE"): "#43B02A",
+    get_tyre_compound_int("WET"):          "#0072CE",
+}
+
+# Moving average window
+_MA_WINDOW = 3
+
+
+def _format_laptime(seconds, _pos=None):
+    """Format lap time as M:SS.sss. Uses 1 decimal place for Y-axis labels."""
+    if seconds <= 0:
+        return ""
+    m = int(seconds // 60)
+    s = seconds % 60
+    
+    if _pos is not None:
+        # Y-axis ticks
+        return f"{m}:{s:04.1f}"
+    
+    # Tooltips and HUD
+    return f"{m}:{s:06.3f}"
+
+
+def _format_delta(seconds, _pos=None):
+    """Format delta time, omitting the '+' sign for exactly 0.0."""
+    if abs(seconds) < 0.0005:  # Effectively zero
+        if _pos is not None:
+            return "0.0"
+        return "0.000s"
+    if _pos is not None:
+        return f"{seconds:+.1f}"
+    return f"{seconds:+.3f}s"
+
+
+def _moving_average(values, window):
+    """Compute a simple moving average, returning same-length array with NaN padding."""
+    if len(values) < window:
+        return values[:]
+    result = []
+    for i in range(len(values)):
+        if i < window - 1:
+            result.append(None)
+        else:
+            avg = sum(values[i - window + 1:i + 1]) / window
+            result.append(avg)
+    return result
+
+
+def _entry_is_pit(entry, pit_threshold):
+    is_pit = entry.get("is_pit")
+    if is_pit is not None:
+        return bool(is_pit)
+    return entry.get("time_s", -1) > pit_threshold and entry.get("lap", 0) > 1
+
+
+def _entry_is_out_lap(entry):
+    return bool(entry.get("is_out_lap"))
+
+
+def _entry_is_outlier(entry, pit_threshold):
+    explicit = entry.get("is_outlier")
+    if explicit is not None:
+        return bool(explicit)
+    return (
+        entry.get("time_s", -1) > pit_threshold
+        and not _entry_is_pit(entry, pit_threshold)
+        and not _entry_is_out_lap(entry)
+    )
+
+
+class LapTimeChartWindow(PitWallWindow):
+    """
+    Pit wall insight that plots lap times for all drivers across the race.
+    """
+
+    def __init__(self):
+        self._lap_times = {}        # code -> list of {"lap", "time_s", "tyre"}
+        self._status_laps = []      # list of {"status", "start_lap", "end_lap"}
+        self._driver_colors = {}    # code -> hex colour
+        self._known_drivers = []
+        self._total_laps = 0
+        self._leader_lap = 0
+        self._last_drawn_lap = 0
+        self._needs_full_redraw = True
+        self._focused_drivers = set()   # set of codes
+        self._y_mode = "absolute"       # "absolute" | "gap"
+        self._has_ever_drawn = False    # True after first successful redraw
+        self._legend_visible = True
+
+        # Crosshair annotation
+        self._annot = None
+        self._crosshair_v = None
+        self._crosshair_h = None
+
+        # Pan state — uses PIXEL coords to avoid feedback loops
+        self._pan_press_px = None    # (px_x, px_y) at mouse-down
+        self._pan_origin_xlim = None
+        self._pan_origin_ylim = None
+        self._pan_active = False
+
+        # Home limits for zoom/pan clamping
+        self._home_xlim = None
+        self._home_ylim = None
+
+        # User zoom state: preserved across live redraws
+        self._user_xlim = None
+        self._user_ylim = None
+        self._view_state_by_mode = {}
+        self._undo_stack = []
+        self._redo_stack = []
+        # Crosshair debounce
+        self._last_crosshair_state = None
+
+        super().__init__()
+
+        # Map graph line artists to driver codes
+        self._artist_to_driver = {}
+        self.setWindowTitle("F1 Race Replay - Lap Time Evolution")
+        self.setGeometry(120, 120, 1000, 600)
+        
+        self.status_bar.setStyleSheet("""
+            QStatusBar {
+                border-top: 1px solid #6A6A6A;
+            }
+            QStatusBar::item {
+                border: none;
+            }
+        """)
+        
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._reposition_overlays()
+
+    def _reposition_overlays(self):
+        """Keep the help overlay centered."""
+        if hasattr(self, '_help_overlay') and self._help_overlay:
+            hx = (self._canvas.width() - self._help_overlay.width()) // 2
+            hy = (self._canvas.height() - self._help_overlay.height()) // 2
+            self._help_overlay.move(max(0, hx), max(0, hy))
+
+    def _gap_ref_s(self, entry):
+        if not entry:
+            return None
+        if entry.get("source") == "official":
+            line_time_s = entry.get("line_time_s")
+            if line_time_s is not None:
+                return float(line_time_s)
+            if entry.get("end_time_s") is not None:
+                return float(entry["end_time_s"])
+        gap_clock_s = entry.get("gap_clock_s")
+        if gap_clock_s is not None:
+            return float(gap_clock_s)
+        return None
+
+    def _official_gap_to_leader_s(self, entry):
+        if not entry:
+            return None
+        gap_s = entry.get("official_gap_to_leader_s")
+        if gap_s is not None:
+            return float(gap_s)
+        return None
+
+    def _official_gap_is_approx(self, entry):
+        if not entry:
+            return False
+        return entry.get("official_gap_source") not in (None, "direct")
+
+    def _official_finish_gap_s(self, entry):
+        if (
+            entry
+            and self._total_laps
+            and self._leader_lap >= self._total_laps
+            and entry.get("lap") == self._total_laps
+        ):
+            gap_s = entry.get("official_finish_gap_s")
+            if gap_s is not None:
+                return float(gap_s)
+        return None
+
+    def _is_approx_time_entry(self, entry):
+        if not entry:
+            return False
+        return (
+            entry.get("time_source") == "frame_backfill"
+            or entry.get("source") == "derived"
+        )
+
+    def _raw_gap_fallback_s(self, entry, leader_refs=None):
+        if not entry or leader_refs is None:
+            return None
+        lap = entry.get("lap")
+        ref = leader_refs.get(lap)
+        if ref is None:
+            return None
+        ref_s = self._gap_ref_s(entry)
+        if ref_s is None:
+            return None
+        return ref_s - ref["ref_s"]
+
+    def _display_gap_meta(self, entry, leader_refs=None, official_gap_laps=None, code=None):
+        if not entry:
+            return None, False
+
+        if code is not None:
+            override = getattr(self, "_cached_gap_overrides", {}).get((code, entry.get("lap")))
+            if override is not None:
+                return (0.0 if -0.05 < override < 0 else override), True
+
+        gap_s = self._official_gap_to_leader_s(entry)
+        if gap_s is not None:
+            return (0.0 if -0.05 < gap_s < 0 else gap_s), self._official_gap_is_approx(entry)
+
+        finish_gap_s = self._official_finish_gap_s(entry)
+        if finish_gap_s is not None:
+            return (0.0 if -0.05 < finish_gap_s < 0 else finish_gap_s), False
+
+        adjusted = None
+        if code is not None:
+            adjusted = getattr(self, "_cached_gap_adjustments", {}).get((code, entry.get("lap")))
+        if adjusted is None:
+            val = self._raw_gap_fallback_s(entry, leader_refs)
+        else:
+            val = adjusted
+        if val is None:
+            return None, False
+        return (0.0 if -0.05 < val < 0 else val), True
+
+    def _display_gap_value(self, entry, leader_refs=None, official_gap_laps=None, code=None):
+        val, _ = self._display_gap_meta(entry, leader_refs, official_gap_laps, code)
+        return val
+
+    def setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+        root.setSpacing(6)
+        root.setContentsMargins(10, 10, 10, 10)
+
+        # Control row
+        ctrl = QHBoxLayout()
+        ctrl.setSpacing(8)
+
+        driver_label = QLabel("Driver:")
+        driver_label.setFont(QFont("Arial", 11))
+        self._driver_combo = QComboBox()
+        self._driver_combo.setMinimumWidth(120)
+        self._driver_combo.setPlaceholderText("Waiting for data…")
+        self._driver_combo.setFont(QFont("Arial", 11))
+        self._driver_combo.addItem("All Drivers")
+        self._driver_combo.currentTextChanged.connect(self._on_driver_changed)
+
+        ctrl.addWidget(driver_label)
+        ctrl.addWidget(self._driver_combo)
+        
+        ctrl.addSpacing(20)
+
+        # Y-axis mode selector
+        ymode_label = QLabel("Y Axis:")
+        ymode_label.setFont(QFont("Arial", 11))
+        self._ymode_combo = QComboBox()
+        self._ymode_combo.setFont(QFont("Arial", 11))
+        self._ymode_combo.addItems(["Lap Time", "Gap to Leader"])
+        self._ymode_combo.currentIndexChanged.connect(self._on_ymode_changed)
+
+        ctrl.addWidget(ymode_label)
+        ctrl.addWidget(self._ymode_combo)
+        ctrl.addSpacing(20)
+
+        self._pure_pace_cb = QCheckBox("Pure Pace (Hide SC/Pits)")
+        self._pure_pace_cb.setFont(QFont("Arial", 11))
+        self._pure_pace_cb.stateChanged.connect(self._on_pure_pace_toggled)
+        ctrl.addWidget(self._pure_pace_cb)
+
+        ctrl.addSpacing(18)
+
+        self._axis_limits_btn = QPushButton("Axis Limits")
+        self._axis_limits_btn.setFont(QFont("Arial", 10))
+        self._axis_limits_btn.clicked.connect(self._open_axis_limits_dialog)
+        ctrl.addWidget(self._axis_limits_btn)
+
+        self._undo_btn = QPushButton("Undo")
+        self._undo_btn.setFont(QFont("Arial", 10))
+        self._undo_btn.clicked.connect(self._undo_view)
+        ctrl.addWidget(self._undo_btn)
+
+        self._redo_btn = QPushButton("Redo")
+        self._redo_btn.setFont(QFont("Arial", 10))
+        self._redo_btn.clicked.connect(self._redo_view)
+        ctrl.addWidget(self._redo_btn)
+        
+        ctrl.addStretch()
+        
+        self._help_btn = QPushButton("?")
+        self._help_btn.setFixedSize(26, 26)
+        self._help_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #333333; color: white;
+                border-radius: 13px; font-weight: bold;
+            }
+            QPushButton:hover { background-color: #555555; }
+        """)
+        self._help_btn.clicked.connect(self._toggle_help)
+        ctrl.addWidget(self._help_btn)
+
+        mono_font = QFont("Consolas", 10)
+        self._lap_status = QLabel("")
+        self._lap_status.setFont(mono_font)
+        self._lap_status.setStyleSheet(f"color: {_TEXT_DIM};")
+        self._lap_status.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        ctrl.addWidget(self._lap_status)
+
+        self._status_sep = QLabel(" · ")
+        self._status_sep.setFont(mono_font)
+        self._status_sep.setStyleSheet(f"color: {_TEXT_DIM};")
+        self._status_sep.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        ctrl.addWidget(self._status_sep)
+
+        self._time_status = QLabel("")
+        self._time_status.setFont(mono_font)
+        self._time_status.setStyleSheet(f"color: {_TEXT_DIM};")
+        self._time_status.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        ctrl.addWidget(self._time_status)
+
+        self._reserve_status_width()
+
+        root.addLayout(ctrl)
+        self._update_history_buttons()
+
+        # tighten layout
+        self._fig, self._ax = plt.subplots(figsize=(6, 4), facecolor=_BG, edgecolor=_BG)
+        self._fig.subplots_adjust(left=0.08, right=0.97, top=0.95, bottom=0.10)
+        self._fig.patch.set_linewidth(0)
+        self._setup_axes(self._ax)
+
+        self._canvas = FigureCanvas(self._fig)
+        self._canvas.setStyleSheet("border: none; outline: none;")
+        self._canvas.setSizePolicy(
+            self._canvas.sizePolicy().horizontalPolicy(),
+            self._canvas.sizePolicy().verticalPolicy(),
+        )
+        root.addWidget(self._canvas, stretch=1)
+
+        # Connect mouse events: crosshair, legend/line pick, scroll-zoom, drag-pan
+        self._canvas.mpl_connect("motion_notify_event", self._on_mouse_move)
+        self._canvas.mpl_connect("pick_event", self._on_pick)
+        self._canvas.mpl_connect("scroll_event", self._on_scroll)
+        self._canvas.mpl_connect("button_press_event", self._on_button_press)
+        self._canvas.mpl_connect("button_release_event", self._on_button_release)
+
+        # Enable pinch-to-zoom gesture on macOS trackpad
+        self._canvas.grabGesture(Qt.GestureType.PinchGesture)
+        self._canvas.installEventFilter(self)
+        self._pinch_scale_accum = 1.0
+
+        self._create_overlays()
+
+    def _create_overlays(self):
+        # Help Overlay
+        self._help_overlay = QLabel(self._canvas)
+        self._help_overlay.setStyleSheet("""
+            QLabel {
+                background-color: #1E1E1E;
+                color: #E0E0E0;
+                border: 1px solid #555555;
+                border-radius: 8px;
+                padding: 20px;
+            }
+            h3 { margin-top: 0; color: #FFFFFF; font-size: 14px; margin-bottom: 8px; }
+            h4 { margin-top: 12px; margin-bottom: 4px; color: #AAAAAA; font-size: 12px; text-transform: uppercase; }
+            ul { margin-top: 0; margin-bottom: 0; padding-left: 20px; }
+            li { margin-bottom: 4px; line-height: 1.4; }
+        """)
+        self._help_overlay.setFont(QFont("Arial", 11))
+        self._help_overlay.setText(
+            "<h3>🏎️ Lap Time Evolution</h3>"
+            "<h4>Key Features</h4>"
+            "<ul>"
+            "<li><b>Tyre Compounds:</b> Markers indicate compound (Soft=●, Medium=■, Hard=▲, Inter=◆, Wet=★)</li>"
+            "<li><b>Stints & Pit Stops:</b> Dashed lines show stint averages; vertical lines with x on top indicate pit stops</li>"
+            "<li><b>Best Laps:</b> <b><font color='#B027C9'>Purple</font></b> = Session Best, <b><font color='#27C93F'>Green</font></b> = Personal Best</li>"
+            "<li><b>Pace Filters:</b> Toggle 'Pure Pace' to hide SC/VSC and pit stop outliers</li>"
+            "<li><b>Gap Mode:</b> Compare each driver's lap-completion time to the leader at the timing line</li>"
+            "</ul>"
+            "<h4>Controls</h4>"
+            "<ul>"
+            "<li><b>Scroll / Pinch:</b> Zoom in & out</li>"
+            "<li><b>Axis Limits:</b> Enter exact X/Y ranges</li>"
+            "<li><b>Left-Click & Drag:</b> Pan around the chart</li>"
+            "<li><b>Undo / Redo:</b> Step backward or forward through chart views</li>"
+            "<li><b>Double-Click:</b> Reset view to full race</li>"
+            "<li><b>Click Legend:</b> Toggle driver isolation for comparison</li>"
+            "<li><b>H:</b> Toggle this help overlay</li>"
+            "<li><b>I:</b> Show or hide the legend</li>"
+            "<li><b>Hover:</b> View exact lap times & tyre life</li>"
+            "</ul>"
+        )
+        self._help_overlay.adjustSize()
+        self._help_overlay.hide()
+
+    def _reserve_status_width(self):
+        if not hasattr(self, "_lap_status"):
+            return
+        sample_total_laps = max(int(self._total_laps or 0), 99)
+        metrics = QFontMetrics(self._lap_status.font())
+        lap_sample = f"Lap {sample_total_laps}/{sample_total_laps}"
+        self._lap_status.setFixedWidth(metrics.horizontalAdvance(lap_sample) + 8)
+        self._status_sep.setFixedWidth(metrics.horizontalAdvance(" · ") + 2)
+        self._time_status.setFixedWidth(metrics.horizontalAdvance("00:00:00") + 8)
+
+    def _setup_axes(self, ax):
+        """Apply consistent styling to the axes."""
+        ax.set_facecolor(_BG)
+        ax.set_xlabel("Lap", color=_TEXT, fontsize=10)
+        if self._y_mode == "gap":
+            ax.set_ylabel("Gap to Leader (s)", color=_TEXT, fontsize=10)
+        else:
+            ax.set_ylabel("Lap Time", color=_TEXT, fontsize=10)
+        ax.tick_params(colors=_TEXT, labelsize=9)
+        if self._y_mode == "absolute":
+            ax.yaxis.set_major_formatter(ticker.FuncFormatter(_format_laptime))
+        else:
+            ax.yaxis.set_major_formatter(ticker.FuncFormatter(_format_delta))
+        ax.grid(True, color=_GRID, alpha=0.5, linewidth=0.5)
+        for spine in ax.spines.values():
+            spine.set_edgecolor("#555555")
+
+    # Telemetry handling
+
+    def on_telemetry_data(self, data):
+        frame = data.get("frame")
+        if not frame:
+            return
+
+        drivers = frame.get("drivers", {})
+        if not drivers:
+            return
+
+        # Capture colours
+        colors = data.get("driver_colors", {})
+        if colors:
+            self._driver_colors = colors
+
+        # Capture session info
+        sd = data.get("session_data", {})
+        if sd:
+            tl = sd.get("total_laps", 0)
+            if tl:
+                self._total_laps = int(tl)
+                self._reserve_status_width()
+            new_leader_lap = sd.get("lap", self._leader_lap)
+            if isinstance(new_leader_lap, (int, float)):
+                self._leader_lap = int(new_leader_lap)
+            self._lap_status.setText(f"Lap {sd.get('lap', '?')}/{self._total_laps or '?'}")
+            self._status_sep.setText(" · ")
+            self._time_status.setText(sd.get('time', ''))
+
+        # Detect rewind
+        if self._leader_lap < self._last_drawn_lap:
+            self._last_drawn_lap = 0
+            self._needs_full_redraw = True
+            self._user_xlim = None
+            self._user_ylim = None
+            self._view_state_by_mode.clear()
+
+        # Ingest pre-computed data from server
+        server_lap_times = data.get("lap_times")
+        if server_lap_times:
+            # Only flag for redraw if data actually changed
+            if server_lap_times is not self._lap_times:
+                self._lap_times = server_lap_times
+                if not self._has_ever_drawn:
+                    self._needs_full_redraw = True
+
+        server_status_laps = data.get("status_laps")
+        if server_status_laps:
+            self._status_laps = server_status_laps
+
+        # Update driver list
+        self._refresh_driver_list(drivers)
+
+        # Redraw when leader crosses a new lap or first data arrival
+        if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw:
+            self._last_drawn_lap = self._leader_lap
+            self._needs_full_redraw = False
+            self._redraw()
+
+    def _refresh_driver_list(self, drivers):
+        incoming = sorted(drivers.keys())
+        if incoming == self._known_drivers:
+            return
+        current = self._driver_combo.currentText()
+        self._driver_combo.blockSignals(True)
+        self._driver_combo.clear()
+        self._driver_combo.addItem("All Drivers")
+        self._driver_combo.addItem("Multiple Drivers")
+        self._driver_combo.addItems(incoming)
+        if current and current in [self._driver_combo.itemText(i) for i in range(self._driver_combo.count())]:
+            self._driver_combo.setCurrentText(current)
+        elif current == "All Drivers":
+            self._driver_combo.setCurrentText("All Drivers")
+        else:
+            self._driver_combo.setCurrentIndex(0)
+        self._driver_combo.blockSignals(False)
+        self._known_drivers = incoming
+
+    def _on_driver_changed(self, text):
+        if text == "Multiple Drivers":
+            return
+        if text == "All Drivers":
+            self._focused_drivers.clear()
+        else:
+            self._focused_drivers = {text}
+        self._needs_full_redraw = True
+        self._redraw()
+
+    def _on_ymode_changed(self, index):
+        self._push_undo_state()
+        self._save_view_state()
+        self._y_mode = "absolute" if index == 0 else "gap"
+        self._restore_view_state()
+        self._needs_full_redraw = True
+        self._redraw()
+
+    def _save_view_state(self):
+        if not getattr(self, "_has_ever_drawn", False):
+            return
+        if not hasattr(self, "_ax"):
+            return
+        self._view_state_by_mode[self._y_mode] = (self._ax.get_xlim(), self._ax.get_ylim())
+
+    def _restore_view_state(self):
+        state = self._view_state_by_mode.get(self._y_mode)
+        if state:
+            self._user_xlim, self._user_ylim = state
+        else:
+            self._user_xlim = None
+            self._user_ylim = None
+
+    def _set_user_view(self, xlim, ylim):
+        self._user_xlim = tuple(xlim)
+        self._user_ylim = tuple(ylim)
+        self._view_state_by_mode[self._y_mode] = (self._user_xlim, self._user_ylim)
+
+    def _capture_view_snapshot(self):
+        if not hasattr(self, "_ax"):
+            return None
+        return {
+            "mode": self._y_mode,
+            "xlim": tuple(self._ax.get_xlim()),
+            "ylim": tuple(self._ax.get_ylim()),
+        }
+
+    def _push_undo_state(self):
+        snapshot = self._capture_view_snapshot()
+        if not snapshot:
+            return
+        if self._undo_stack and self._undo_stack[-1] == snapshot:
+            return
+        self._undo_stack.append(snapshot)
+        self._redo_stack.clear()
+        self._update_history_buttons()
+
+    def _restore_view_snapshot(self, snapshot):
+        if not snapshot:
+            return
+        mode = snapshot.get("mode", self._y_mode)
+        if mode != self._y_mode:
+            self._y_mode = mode
+            self._ymode_combo.blockSignals(True)
+            self._ymode_combo.setCurrentIndex(0 if mode == "absolute" else 1)
+            self._ymode_combo.blockSignals(False)
+            self._user_xlim = tuple(snapshot["xlim"])
+            self._user_ylim = tuple(snapshot["ylim"])
+            self._needs_full_redraw = True
+            self._redraw()
+            self._update_history_buttons()
+            return
+        self._ax.set_xlim(snapshot["xlim"])
+        self._ax.set_ylim(snapshot["ylim"])
+        self._set_user_view(snapshot["xlim"], snapshot["ylim"])
+        self._update_history_buttons()
+        self._canvas.draw_idle()
+
+    def _undo_view(self):
+        if not self._undo_stack:
+            return
+        current = self._capture_view_snapshot()
+        previous = self._undo_stack.pop()
+        if current:
+            self._redo_stack.append(current)
+        self._restore_view_snapshot(previous)
+        self._update_history_buttons()
+
+    def _redo_view(self):
+        if not self._redo_stack:
+            return
+        current = self._capture_view_snapshot()
+        nxt = self._redo_stack.pop()
+        if current:
+            self._undo_stack.append(current)
+        self._restore_view_snapshot(nxt)
+        self._update_history_buttons()
+
+    def _update_history_buttons(self):
+        if hasattr(self, "_undo_btn"):
+            self._undo_btn.setEnabled(bool(self._undo_stack))
+        if hasattr(self, "_redo_btn"):
+            self._redo_btn.setEnabled(bool(self._redo_stack))
+
+    def _open_axis_limits_dialog(self):
+        if not hasattr(self, "_ax"):
+            return
+        x_lo, x_hi = self._ax.get_xlim()
+        y_lo, y_hi = self._ax.get_ylim()
+        allowed_x_lo, allowed_x_hi = self._home_xlim if self._home_xlim else (x_lo, x_hi)
+        allowed_y_lo, allowed_y_hi = self._max_ylim if hasattr(self, "_max_ylim") else (y_lo, y_hi)
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Axis Limits")
+        form = QFormLayout(dialog)
+        spinboxes = []
+        for label, value, min_value, max_value, step in (
+            ("X min", x_lo, allowed_x_lo, allowed_x_hi, 1.0),
+            ("X max", x_hi, allowed_x_lo, allowed_x_hi, 1.0),
+            ("Y min", y_lo, allowed_y_lo, allowed_y_hi, 1.0),
+            ("Y max", y_hi, allowed_y_lo, allowed_y_hi, 1.0),
+        ):
+            spin = QDoubleSpinBox(dialog)
+            spin.setRange(float(min_value), float(max_value))
+            spin.setDecimals(3)
+            spin.setSingleStep(step)
+            spin.setValue(float(min(max(value, min_value), max_value)))
+            form.addRow(label, spin)
+            spinboxes.append(spin)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            parent=dialog,
+        )
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        form.addRow(buttons)
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        new_x_lo, new_x_hi, new_y_lo, new_y_hi = [spin.value() for spin in spinboxes]
+        new_x_lo = max(allowed_x_lo, min(new_x_lo, allowed_x_hi))
+        new_x_hi = max(allowed_x_lo, min(new_x_hi, allowed_x_hi))
+        new_y_lo = max(allowed_y_lo, min(new_y_lo, allowed_y_hi))
+        new_y_hi = max(allowed_y_lo, min(new_y_hi, allowed_y_hi))
+        if new_x_hi <= new_x_lo or new_y_hi <= new_y_lo:
+            return
+        self._push_undo_state()
+        self._ax.set_xlim(new_x_lo, new_x_hi)
+        self._ax.set_ylim(new_y_lo, new_y_hi)
+        self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+        self._canvas.draw_idle()
+
+    def _on_pure_pace_toggled(self, state):
+        self._needs_full_redraw = True
+        self._redraw()
+
+    def _toggle_help(self):
+        if self._help_overlay.isHidden():
+            self._reposition_overlays()
+            self._help_overlay.show()
+            self._help_overlay.raise_()
+        else:
+            self._help_overlay.hide()
+
+    # Chart rendering
+
+    def _redraw(self):
+        ax = self._ax
+        ax.clear()
+        self._setup_axes(ax)
+        self._annot = None
+        self._legend_artist = None
+
+        if not self._lap_times:
+            self._canvas.draw_idle()
+            return
+
+        focus = self._focused_drivers
+
+        # Show completed laps only during replay, but include the final lap once
+        # the race has actually finished.
+        visible_data = {}
+        lap_cutoff = self._leader_lap
+        include_final_lap = self._total_laps and self._leader_lap >= self._total_laps
+        for code, entries in self._lap_times.items():
+            terminal_lap = next((e["lap"] for e in entries if e.get("is_terminal_lap")), None)
+            effective_cutoff = lap_cutoff
+            if terminal_lap is not None:
+                effective_cutoff = min(effective_cutoff, terminal_lap)
+            if include_final_lap:
+                visible = [e for e in entries if e["lap"] <= effective_cutoff]
+            else:
+                visible = [e for e in entries if e["lap"] < effective_cutoff or (e.get("is_terminal_lap") and e["lap"] == effective_cutoff)]
+            if visible:
+                visible_data[code] = visible
+
+        if not visible_data:
+            self._canvas.draw_idle()
+            return
+
+        pure_pace = self._pure_pace_cb.isChecked()
+        sc_vsc_laps = set()
+        
+        # ── 1. Safety Car / VSC shaded zones ──
+        # Merge overlapping/adjacent periods into unified visual spans
+        # to prevent label overlap (e.g. VSC → SC on consecutive laps).
+        merged_zones = []
+        for sp in self._status_laps:
+            if sp["start_lap"] > self._leader_lap:
+                continue
+            end_lap = min(sp["end_lap"], self._leader_lap)
+            status = sp["status"]
+            if status == "4":
+                colour, label = _SC_COLOUR, "SC"
+            elif status in ("6", "7"):
+                colour, label = _VSC_COLOUR, "VSC"
+            elif status == "5":
+                colour, label = _RED_FLAG_COLOUR, "RED"
+            else:
+                continue
+                
+            # Record SC laps to filter them out of pace calcs
+            for l in range(sp["start_lap"], end_lap + 1):
+                sc_vsc_laps.add(l)
+
+        # Compute median for pit lap filtering (excluding SC laps for accuracy)
+        clean_times = [e["time_s"] for v in visible_data.values() for e in v if e["lap"] not in sc_vsc_laps]
+        if clean_times:
+            clean_times.sort()
+            median_time = clean_times[len(clean_times) // 2]
+            # A pit stop always adds at least ~18-20s. We use max(15, 10%) to be robust 
+            # for both short tracks (Austria) and long tracks (Spa).
+            pit_threshold = median_time + max(15.0, median_time * 0.12)
+        else:
+            pit_threshold = 9999.0
+            
+        self._cached_pit_threshold = pit_threshold
+        self._cached_sc_vsc_laps = sc_vsc_laps
+
+        # Build timing-screen-style gap references for gap mode.
+        # For lap N, the baseline is the first classified driver to complete
+        # lap N. Drivers behind should therefore be >= 0 unless source timing
+        # data is inconsistent.
+        lap_entry_lookup = {
+            code: {e["lap"]: e for e in entries if e["time_s"] > 0}
+            for code, entries in visible_data.items()
+        }
+        leader_refs = {}
+        if self._y_mode == "gap":
+            for lap in sorted({e["lap"] for entries in visible_data.values() for e in entries}):
+                official_candidates = []
+                candidates = []
+                for code, lap_entries in lap_entry_lookup.items():
+                    entry = lap_entries.get(lap)
+                    official_gap_s = self._official_gap_to_leader_s(entry)
+                    if official_gap_s is not None:
+                        official_candidates.append((official_gap_s, code, entry))
+                    ref_s = self._gap_ref_s(entry)
+                    if ref_s is not None:
+                        candidates.append((ref_s, code, entry))
+                if official_candidates:
+                    _, leader_code, entry = min(official_candidates, key=lambda item: item[0])
+                    leader_refs[lap] = {
+                        "code": leader_code,
+                        "time_s": entry["time_s"],
+                        "ref_s": self._gap_ref_s(entry),
+                        "uses_official_gap": True,
+                    }
+                elif candidates:
+                    ref_s, leader_code, entry = min(candidates, key=lambda item: item[0])
+                    leader_refs[lap] = {
+                        "code": leader_code,
+                        "time_s": entry["time_s"],
+                        "ref_s": ref_s,
+                        "uses_official_gap": False,
+                    }
+        gap_adjustments = {}
+        gap_overrides = {}
+        if self._y_mode == "gap":
+            for code, entries in visible_data.items():
+                sorted_entries = sorted(entries, key=lambda item: item["lap"])
+                anchors = []
+                for entry in sorted_entries:
+                    official_val = self._official_gap_to_leader_s(entry)
+                    if official_val is None:
+                        official_val = self._official_finish_gap_s(entry)
+                    raw_val = self._raw_gap_fallback_s(entry, leader_refs)
+                    if official_val is not None and raw_val is not None:
+                        anchors.append({
+                            "lap": entry["lap"],
+                            "offset": float(official_val) - float(raw_val),
+                        })
+
+                if not anchors:
+                    continue
+
+                for entry in sorted_entries:
+                    if self._official_gap_to_leader_s(entry) is not None or self._official_finish_gap_s(entry) is not None:
+                        continue
+                    raw_val = self._raw_gap_fallback_s(entry, leader_refs)
+                    if raw_val is None:
+                        continue
+                    lap = entry["lap"]
+                    prev_anchor = None
+                    next_anchor = None
+                    for anchor in anchors:
+                        if anchor["lap"] < lap:
+                            prev_anchor = anchor
+                        elif anchor["lap"] > lap:
+                            next_anchor = anchor
+                            break
+                    if prev_anchor and next_anchor:
+                        span = next_anchor["lap"] - prev_anchor["lap"]
+                        if span > 0:
+                            t = (lap - prev_anchor["lap"]) / span
+                            offset = prev_anchor["offset"] + t * (next_anchor["offset"] - prev_anchor["offset"])
+                        else:
+                            offset = prev_anchor["offset"]
+                    elif prev_anchor:
+                        offset = prev_anchor["offset"]
+                    elif next_anchor:
+                        offset = next_anchor["offset"]
+                    else:
+                        continue
+                    gap_adjustments[(code, lap)] = raw_val + offset
+            gap_override_threshold = 5.0
+            for code, entries in visible_data.items():
+                sorted_entries = sorted(entries, key=lambda item: item["lap"])
+                prev_gap = None
+                for entry in sorted_entries:
+                    lap = entry["lap"]
+                    leader_ref = leader_refs.get(lap)
+                    leader_time_s = None if leader_ref is None else leader_ref.get("time_s")
+                    official_val = self._official_gap_to_leader_s(entry)
+                    if official_val is None:
+                        official_val = self._official_finish_gap_s(entry)
+                    fallback_val = gap_adjustments.get((code, lap))
+                    if fallback_val is None:
+                        fallback_val = self._raw_gap_fallback_s(entry, leader_refs)
+
+                    display_val = official_val if official_val is not None else fallback_val
+                    if (
+                        official_val is not None
+                        and prev_gap is not None
+                        and entry.get("time_s", -1) > 0
+                        and leader_time_s is not None
+                        and leader_time_s > 0
+                    ):
+                        predicted = prev_gap + float(entry["time_s"]) - float(leader_time_s)
+                        if (
+                            abs(float(official_val) - predicted) > gap_override_threshold
+                            and (
+                                _entry_is_pit(entry, pit_threshold)
+                                or _entry_is_out_lap(entry)
+                                or _entry_is_outlier(entry, pit_threshold)
+                            )
+                        ):
+                            gap_overrides[(code, lap)] = predicted
+                            display_val = predicted
+
+                    if display_val is not None:
+                        prev_gap = float(display_val)
+        official_gap_laps = {
+            lap for lap, ref in leader_refs.items() if ref.get("uses_official_gap")
+        }
+
+        # Cache variables for O(1) lookups during high-frequency mouse hover events
+        self._cached_visible_data = visible_data
+        self._cached_pit_threshold = pit_threshold
+        self._cached_leader_refs = leader_refs
+        self._cached_official_gap_laps = official_gap_laps
+        self._cached_gap_adjustments = gap_adjustments
+        self._cached_gap_overrides = gap_overrides
+        self._cached_terminal_no_time_points = []
+                        
+        for sp in self._status_laps:
+            if sp["start_lap"] > self._leader_lap:
+                continue
+            end_lap = min(sp["end_lap"], self._leader_lap)
+            status = sp["status"]
+            if status not in ("4", "5", "6", "7"):
+                continue
+            if status == "4":
+                colour, label = _SC_COLOUR, "SC"
+            elif status in ("6", "7"):
+                colour, label = _VSC_COLOUR, "VSC"
+            elif status == "5":
+                colour, label = _RED_FLAG_COLOUR, "RED"
+            
+            # Check if this zone overlaps/touches the previous one
+            if merged_zones and sp["start_lap"] <= merged_zones[-1]["end"] + 1:
+                prev = merged_zones[-1]
+                prev["end"] = max(prev["end"], end_lap)
+                # Combine labels if different (e.g. "VSC → SC")
+                if label not in prev["label"]:
+                    prev["label"] += f"→{label}"
+                    prev["colour"] = colour  # use the later period's colour
+            else:
+                merged_zones.append({
+                    "start": sp["start_lap"], "end": end_lap,
+                    "colour": colour, "label": label,
+                })
+
+        for zone in merged_zones:
+            ax.axvspan(
+                zone["start"] - 0.5, zone["end"] + 0.5,
+                color=zone["colour"], alpha=0.08, zorder=0,
+            )
+            mid = (zone["start"] + zone["end"]) / 2
+            ax.text(
+                mid, 1.02, zone["label"],
+                transform=ax.get_xaxis_transform(),
+                ha="center", va="bottom", fontsize=7, fontweight="bold",
+                color=zone["colour"], alpha=0.7,
+            )
+
+        # ── 2-6. Per-driver rendering ──
+        y_min = float("inf")
+        y_max = float("-inf")
+
+        # Store line references for picking
+        self._artist_to_driver = {}
+        driver_stints_text = {}
+        display_y_vals = []
+        all_axis_y_vals = []
+
+        session_best = float("inf")
+        session_best_code = None
+        for code_sb, entries in visible_data.items():
+            for e in entries:
+                if (
+                    0 < e["time_s"] <= pit_threshold
+                    and e["lap"] not in sc_vsc_laps
+                    and not _entry_is_pit(e, pit_threshold)
+                    and not _entry_is_out_lap(e)
+                    and not _entry_is_outlier(e, pit_threshold)
+                ):
+                    if e["time_s"] < session_best:
+                        session_best = e["time_s"]
+                        session_best_code = code_sb
+        self._cached_session_best = session_best
+        self._cached_session_best_code = session_best_code
+        self._cached_driver_personal_bests = {}
+
+        for code, entries in visible_data.items():
+            colour = self._driver_colors.get(code, _DEFAULT_COLOUR)
+
+            if focus:
+                is_focused = code in focus
+                alpha = 1.0 if is_focused else 0.10
+                lw = 2.2 if is_focused else 0.6
+                zorder = 10 if is_focused else 1
+                show_detail = is_focused
+            else:
+                alpha = 0.75
+                lw = 1.2
+                zorder = 2
+                show_detail = True
+
+            clean_laps, clean_vals, clean_time_s, clean_tyres = [], [], [], []
+            pit_laps, pit_vals = [], []
+            all_laps, all_vals, all_markers = [], [], []
+            terminal_no_time_laps = []
+            
+            drv_clean_times = [
+                e["time_s"] for e in entries
+                if (
+                    0 < e["time_s"] <= pit_threshold
+                    and e["lap"] not in sc_vsc_laps
+                    and not _entry_is_pit(e, pit_threshold)
+                    and not _entry_is_out_lap(e)
+                    and not _entry_is_outlier(e, pit_threshold)
+                )
+            ]
+            personal_best = min(drv_clean_times) if drv_clean_times else float("inf")
+            self._cached_driver_personal_bests[code] = personal_best
+
+            for e in entries:
+                lap = e["lap"]
+                raw_time = e["time_s"]
+                is_pit = _entry_is_pit(e, pit_threshold)
+                is_out_lap = _entry_is_out_lap(e)
+                is_outlier = _entry_is_outlier(e, pit_threshold)
+
+                if pure_pace and (lap in sc_vsc_laps or is_pit or is_out_lap or is_outlier):
+                    continue
+
+                if self._y_mode == "gap":
+                    val = self._display_gap_value(e, leader_refs, official_gap_laps, code)
+                    if val is None:
+                        if is_pit:
+                            pit_laps.append(lap)
+                            pit_vals.append(0)
+                        continue
+                else:
+                    if raw_time < 0:
+                        if e.get("is_terminal_lap"):
+                            terminal_no_time_laps.append(lap)
+                        if is_pit:
+                            pit_laps.append(lap)
+                            pit_vals.append(0) # Dummy value, won't be plotted on main line
+                        continue
+                    val = raw_time
+                    
+                all_laps.append(lap)
+                all_vals.append(val)
+                all_markers.append(_TYRE_MARKERS.get(e.get("tyre", -1), _DEFAULT_MARKER))
+
+                if is_pit:
+                    # Explicit pit stop (In-Lap)
+                    pit_laps.append(lap)
+                    pit_vals.append(val)
+                elif is_out_lap or is_outlier:
+                    # Just a really slow lap (like a standing start or an Out-Lap).
+                    # Ignore it completely so it doesn't squish the Y-axis.
+                    pass
+                else:
+                    clean_laps.append(lap)
+                    clean_vals.append(val)
+                    clean_time_s.append(raw_time)
+                    clean_tyres.append(e.get("tyre", -1))
+
+            # Main pace line
+            if all_laps:
+                line, = ax.plot(
+                    all_laps, all_vals,
+                    color=colour, alpha=alpha, linewidth=lw,
+                    zorder=zorder,
+                    label=code,
+                )
+                self._artist_to_driver[line] = code
+
+                purple_laps, purple_vals = [], []
+                green_laps, green_vals = [], []
+                for lp, tv, ts in zip(clean_laps, clean_vals, clean_time_s):
+                    if ts == session_best and session_best < float("inf"):
+                        purple_laps.append(lp)
+                        purple_vals.append(tv)
+                    elif ts == personal_best and personal_best < float("inf"):
+                        green_laps.append(lp)
+                        green_vals.append(tv)
+                
+                if green_laps and focus and is_focused:
+                    ax.scatter(green_laps, green_vals, color="#00FF00", edgecolors="black", linewidths=0.5, zorder=zorder+3, s=40)
+                if purple_laps:
+                    ax.scatter(purple_laps, purple_vals, color="#800080", edgecolors="white", linewidths=0.8, zorder=zorder+4, s=45)
+
+                # ── 3. Tyre compound markers ──
+                prev_mk = None
+                gx, gy = [], []
+                for lp, tv, mk in zip(all_laps, all_vals, all_markers):
+                    if mk != prev_mk and gx:
+                        ax.scatter(
+                            gx, gy, marker=prev_mk,
+                            color=colour, alpha=alpha * 0.9,
+                            s=22 if show_detail else 6,
+                            zorder=zorder + 1, edgecolors="none",
+                        )
+                        gx, gy = [], []
+                    gx.append(lp)
+                    gy.append(tv)
+                    prev_mk = mk
+                if gx:
+                    ax.scatter(
+                        gx, gy, marker=prev_mk,
+                        color=colour, alpha=alpha * 0.9,
+                        s=22 if show_detail else 6,
+                        zorder=zorder + 1, edgecolors="none",
+                    )
+
+                # ── 5. Tyre stint background bands (focused driver only) ──
+                if show_detail and focus:
+                    drv_pit_lap_set = {e["lap"] for e in entries if _entry_is_pit(e, pit_threshold)}
+                    stint_str = self._draw_stint_bands(ax, clean_laps, clean_vals, clean_tyres, zorder - 1, drv_pit_lap_set)
+                    if stint_str:
+                        driver_stints_text[code] = stint_str
+
+                # ── 2. Pace trend line (3-lap moving average) ──
+                # Only show for the focused driver to reduce clutter
+                if focus and is_focused and len(clean_vals) >= _MA_WINDOW:
+                    ma = _moving_average(clean_vals, _MA_WINDOW)
+                    ma_laps = [l for l, v in zip(clean_laps, ma) if v is not None]
+                    ma_vals = [v for v in ma if v is not None]
+                    if ma_laps:
+                        ax.plot(
+                            ma_laps, ma_vals,
+                            color=colour, alpha=alpha * 0.5,
+                            linewidth=lw + 1.5, linestyle="--",
+                            zorder=zorder - 1,
+                        )
+
+                for v in clean_vals:
+                    y_min = min(y_min, v)
+                    y_max = max(y_max, v)
+                display_y_vals.extend(clean_vals)
+                all_axis_y_vals.extend(clean_vals)
+
+            # ── 4. Pit stop vertical markers & × markers ──
+            # Only show when a driver is focused (in All Drivers view,
+            # dozens of pit-lap outlier points create noise)
+            if pit_laps and focus and is_focused and not pure_pace:
+                for pl in pit_laps:
+                    ax.axvline(
+                        pl, color=colour, alpha=0.3,
+                        linewidth=0.8, linestyle=":",
+                        zorder=zorder - 2,
+                    )
+                    ax.scatter(
+                        pl, 0.95, marker="x",
+                        color=colour, alpha=0.6, s=35,
+                        zorder=zorder, linewidths=1.5,
+                        transform=ax.get_xaxis_transform()
+                    )
+
+            if terminal_no_time_laps and focus and is_focused and self._y_mode == "time":
+                for pl in terminal_no_time_laps:
+                    status_text = next(
+                        (
+                            e.get("result_status", "Retired")
+                            for e in entries
+                            if e.get("lap") == pl and e.get("is_terminal_lap")
+                        ),
+                        "Retired",
+                    )
+                    self._cached_terminal_no_time_points.append({
+                        "code": code,
+                        "lap": pl,
+                        "colour": colour,
+                        "alpha": alpha,
+                        "zorder": zorder + 2,
+                        "status": status_text,
+                    })
+
+        # ── 4b. HUD Statistics (prepared for drawing at the end) ──
+        hud_handles, hud_labels = [], []
+        if focus and len(focus) <= 4:
+            import matplotlib.lines as mlines
+            for code in sorted(focus):
+                if code not in visible_data: continue
+                # Calculate best lap and avg true pace
+                drv_clean_times = [
+                    e["time_s"] for e in visible_data[code] 
+                    if (
+                        e["time_s"] <= pit_threshold
+                        and e["lap"] not in sc_vsc_laps
+                        and not _entry_is_pit(e, pit_threshold)
+                        and not _entry_is_out_lap(e)
+                        and not _entry_is_outlier(e, pit_threshold)
+                    )
+                ]
+                # Count actual pit stops (group consecutive in/out laps)
+                pit_laps = [e["lap"] for e in visible_data[code] if _entry_is_pit(e, pit_threshold)]
+                drv_pit_stops = len(pit_laps)
+                
+                if drv_clean_times:
+                    best = min(drv_clean_times)
+                    avg = sum(drv_clean_times) / len(drv_clean_times)
+                    hex_col = self._driver_colors.get(code, "#FFFFFF")
+                    hud_handles.append(
+                        mlines.Line2D([], [], color=hex_col, marker='s', linestyle='None', markersize=5)
+                    )
+                    stint_str = driver_stints_text.get(code, "")
+                    if stint_str:
+                        hud_labels.append(f'{code} | Best: {_format_laptime(best)} | Avg: {_format_laptime(avg)} | Stops: {drv_pit_stops} | Stints: {stint_str}')
+                    else:
+                        hud_labels.append(f'{code} | Best: {_format_laptime(best)} | Avg: {_format_laptime(avg)} | Stops: {drv_pit_stops}')
+
+        # Y-axis padding. Gap mode defaults to a useful battle view instead
+        # of letting retired or long-stopped cars flatten the competitive field.
+        if display_y_vals:
+            if self._y_mode == "gap":
+                # Keep a stable default race-gap view even when a driver is
+                # focused. Long garage stops / repairs should not re-scale the
+                # whole chart around one outlier trace.
+                inliers = [v for v in display_y_vals if v <= 120.0]
+                y_hi = max(inliers) if len(inliers) >= 5 else float(np.percentile(display_y_vals, 85))
+                ax.set_ylim(-5.0, max(5.0, y_hi + max(2.0, y_hi * 0.08)))
+            elif all_axis_y_vals:
+                y_min_display = min(all_axis_y_vals)
+                y_max_display = max(all_axis_y_vals)
+                pad = max(2.0, (y_max_display - y_min_display) * 0.06)
+                ax.set_ylim(y_min_display - pad, y_max_display + pad)
+
+        if self._cached_terminal_no_time_points and self._y_mode == "time":
+            y_lo, y_hi = ax.get_ylim()
+            span = max(y_hi - y_lo, 1.0)
+            marker_y = y_hi - span * 0.045
+            for point in self._cached_terminal_no_time_points:
+                point["val"] = marker_y
+                ax.scatter(
+                    point["lap"], marker_y,
+                    marker="o", facecolors=_BG, edgecolors=point["colour"],
+                    alpha=point["alpha"], s=46, linewidths=1.4,
+                    zorder=point["zorder"],
+                )
+
+        # X-axis
+        all_laps = [e["lap"] for v in visible_data.values() for e in v]
+        if all_laps:
+            x_max = max(self._total_laps, max(all_laps)) + 0.5
+            ax.set_xlim(min(all_laps) - 0.5, x_max)
+            ax.xaxis.set_major_locator(ticker.MaxNLocator(integer=True))
+
+        # ── 6. Interactive legend (click to isolate) ──
+        handles, labels = ax.get_legend_handles_labels()
+        if handles and self._legend_visible:
+            leg = ax.legend(
+                loc="upper right", fontsize=7, framealpha=0.6,
+                facecolor=_BG, edgecolor="#555555", labelcolor=_TEXT,
+                ncol=2 if len(handles) > 10 else 1,
+            )
+            self._legend_artist = leg
+            # Make legend items pickable
+            self._legend_map = {}
+            for leg_line, orig_label in zip(leg.get_lines(), labels):
+                leg_line.set_picker(5)
+                leg_line.set_pickradius(5)
+                self._legend_map[leg_line] = orig_label
+            ax.add_artist(leg)
+
+        # ── 7. HUD Statistics Legend ──
+        if hud_handles:
+            # Place HUD in the top left, but slightly offset so it doesn't overlap the coordinates readout
+            hud_leg = ax.legend(
+                hud_handles, hud_labels,
+                loc="upper left", bbox_to_anchor=(0.0, 1.0),
+                fontsize=8, framealpha=0.85,
+                facecolor=_BG, edgecolor="#555555", labelcolor=_TEXT
+            )
+            hud_leg.set_zorder(50)
+
+        # Setup crosshair annotation (hidden by default)
+        self._annot = ax.annotate(
+            "", xy=(0, 0), xytext=(15, 15),
+            textcoords="offset points",
+            bbox=dict(boxstyle="round,pad=0.4", fc="#1E1E1E", ec="#555555", alpha=0.92),
+            fontsize=8, color=_TEXT,
+            arrowprops=dict(arrowstyle="->", color="#666666"),
+            zorder=100,
+        )
+        self._annot.set_visible(False)
+
+        # Crosshair lines
+        self._crosshair_v = ax.axvline(0, color="#555555", linewidth=0.5, linestyle="--", visible=False, zorder=99)
+        self._crosshair_h = ax.axhline(0, color="#555555", linewidth=0.5, linestyle="--", visible=False, zorder=99)
+
+
+        # Store home limits for zoom clamping
+        self._home_xlim = ax.get_xlim()
+        self._home_ylim = ax.get_ylim()
+
+        all_v = []
+        for vlist in visible_data.values():
+            for e in vlist:
+                if self._y_mode == "gap":
+                    val = self._display_gap_value(e, leader_refs, official_gap_laps)
+                    if val is not None:
+                        all_v.append(val)
+                else:
+                    if e["time_s"] < 0:
+                        continue
+                    all_v.append(e["time_s"])
+        
+        if all_v:
+            y_min_abs, y_max_abs = min(all_v), max(all_v)
+            pad_abs = (y_max_abs - y_min_abs) * 0.05
+            if self._y_mode == "gap":
+                self._max_ylim = (-5.0, y_max_abs + max(2.0, pad_abs))
+            else:
+                # Keep the normal analytical lower bound from the default
+                # visible view, but still allow users to pan/zoom upward into
+                # anomalously long pit/garage laps when they want to inspect
+                # them explicitly.
+                self._max_ylim = (self._home_ylim[0], y_max_abs + pad_abs)
+        else:
+            self._max_ylim = self._home_ylim
+
+        # If user had a custom zoom/pan, restore it
+        if self._user_xlim is not None:
+            ax.set_xlim(self._user_xlim)
+        if self._user_ylim is not None:
+            ax.set_ylim(self._user_ylim)
+
+        self._has_ever_drawn = True
+        self._canvas.draw_idle()
+
+    def _draw_stint_bands(self, ax, laps, vals, tyres, zorder, pit_laps=None):
+        """Draw faint tyre-coloured background bands behind the focused driver's line, and return stint averages."""
+        if not laps:
+            return ""
+        
+        if pit_laps is None:
+            pit_laps = set()
+        
+        stints = []
+        stint_start_idx = 0
+        stint_tyre = tyres[0]
+        
+        for i in range(1, len(laps) + 1):
+            # Detect stint boundary: compound change OR a pit stop occurred in the gap
+            compound_change = (i < len(laps) and tyres[i] != stint_tyre)
+            pit_in_gap = False
+            if i < len(laps) and laps[i] - laps[i - 1] > 1:
+                # Check if any lap in the gap was an actual pit stop
+                for gap_lap in range(laps[i - 1], laps[i] + 1):
+                    if gap_lap in pit_laps:
+                        pit_in_gap = True
+                        break
+            is_boundary = (i == len(laps)) or compound_change or pit_in_gap
+            if is_boundary:
+                end_idx = i - 1
+                start_lap = laps[stint_start_idx]
+                end_lap = laps[end_idx]
+                
+                colour = _TYRE_COLOURS.get(stint_tyre, "#666666")
+                ax.axvspan(
+                    start_lap - 0.5, end_lap + 0.5,
+                    color=colour, alpha=0.04, zorder=zorder,
+                )
+                
+                stint_vals = vals[stint_start_idx:end_idx+1]
+                if stint_vals:
+                    avg_val = sum(stint_vals) / len(stint_vals)
+                    ax.hlines(avg_val, start_lap - 0.5, end_lap + 0.5, color=colour, linestyle='--', alpha=0.8, zorder=zorder + 2)
+                    
+                    tyre_name = get_tyre_compound_str(stint_tyre)
+                    if tyre_name:
+                        tyre_char = tyre_name[0].upper()
+                        if self._y_mode == "gap":
+                            stints.append(f"{tyre_char}({_format_delta(avg_val)})")
+                        else:
+                            stints.append(f"{tyre_char}({_format_laptime(avg_val)})")
+
+                if i < len(laps):
+                    stint_start_idx = i
+                    stint_tyre = tyres[i]
+                    
+        return ", ".join(stints)
+
+    # Interactive features
+
+    def _px_to_data_delta(self, dx_px, dy_px):
+        """Convert pixel deltas to data-coordinate deltas using the axes transform."""
+        inv = self._ax.transData.inverted()
+        origin = inv.transform((0, 0))
+        moved = inv.transform((dx_px, dy_px))
+        return moved[0] - origin[0], moved[1] - origin[1]
+
+    def _on_mouse_move(self, event):
+        """Crosshair + tooltip on hover, and pixel-based drag-to-pan."""
+        # Guard: ignore events with no valid data coordinates
+        if event.xdata is None or event.ydata is None:
+            if self._annot and self._annot.get_visible():
+                self._annot.set_visible(False)
+                if self._crosshair_v:
+                    self._crosshair_v.set_visible(False)
+                if self._crosshair_h:
+                    self._crosshair_h.set_visible(False)
+                self._last_crosshair_state = None
+                self._canvas.draw_idle()
+            return
+
+        if self._is_over_legend(event):
+            self._hide_hover()
+            return
+
+        # Handle panning using PIXEL deltas (avoids feedback loop)
+        if self._pan_press_px is not None:
+            dx_px = event.x - self._pan_press_px[0]
+            dy_px = event.y - self._pan_press_px[1]
+            if not self._pan_active:
+                if abs(dx_px) > 5 or abs(dy_px) > 5:
+                    self._pan_active = True
+                else:
+                    return
+            if self._pan_active:
+                # Convert pixel delta to data delta
+                ddx, ddy = self._px_to_data_delta(dx_px, dy_px)
+                ox_lo, ox_hi = self._pan_origin_xlim
+                oy_lo, oy_hi = self._pan_origin_ylim
+                # Subtract because dragging right should move view left
+                new_x_lo, new_x_hi = ox_lo - ddx, ox_hi - ddx
+                new_y_lo, new_y_hi = oy_lo - ddy, oy_hi - ddy
+                # Clamp to home boundaries
+                if self._home_xlim:
+                    hx_lo, hx_hi = self._home_xlim
+                    if new_x_lo < hx_lo:
+                        shift = hx_lo - new_x_lo
+                        new_x_lo, new_x_hi = new_x_lo + shift, new_x_hi + shift
+                    if new_x_hi > hx_hi:
+                        shift = new_x_hi - hx_hi
+                        new_x_lo, new_x_hi = new_x_lo - shift, new_x_hi - shift
+                if hasattr(self, '_max_ylim'):
+                    hy_lo, hy_hi = self._max_ylim
+                    if new_y_lo < hy_lo:
+                        shift = hy_lo - new_y_lo
+                        new_y_lo, new_y_hi = new_y_lo + shift, new_y_hi + shift
+                    if new_y_hi > hy_hi:
+                        shift = new_y_hi - hy_hi
+                        new_y_lo, new_y_hi = new_y_lo - shift, new_y_hi - shift
+                self._ax.set_xlim(new_x_lo, new_x_hi)
+                self._ax.set_ylim(new_y_lo, new_y_hi)
+                self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+                self._pan_active = True
+                self._canvas.draw_idle()
+                return
+
+
+        if not event.inaxes or self._annot is None:
+            if self._annot and self._annot.get_visible():
+                self._annot.set_visible(False)
+                if self._crosshair_v:
+                    self._crosshair_v.set_visible(False)
+                if self._crosshair_h:
+                    self._crosshair_h.set_visible(False)
+                self._canvas.draw_idle()
+            return
+
+        # Find nearest data point
+        best_dist_px2 = float("inf")
+        best_info = None
+
+        focus = self._focused_drivers
+        visible_data = getattr(self, '_cached_visible_data', None)
+        if not visible_data:
+            return
+
+        pit_threshold = getattr(self, '_cached_pit_threshold', float('inf'))
+        leader_refs = getattr(self, '_cached_leader_refs', {})
+        official_gap_laps = getattr(self, '_cached_official_gap_laps', set())
+        terminal_no_time_points = getattr(self, '_cached_terminal_no_time_points', [])
+
+        for code, entries in visible_data.items():
+            is_focused_drv = (not focus) or (code in focus)
+            session_best_val = getattr(self, '_cached_session_best', float('inf'))
+            
+            if not is_focused_drv:
+                # For non-focused drivers, only check their session-best lap
+                entries = [e for e in entries if e["time_s"] == session_best_val]
+                if not entries:
+                    continue
+            for e in entries:
+                if self._pure_pace_cb.isChecked() and (
+                    _entry_is_pit(e, pit_threshold)
+                    or _entry_is_out_lap(e)
+                    or _entry_is_outlier(e, pit_threshold)
+                    or e["lap"] in getattr(self, '_cached_sc_vsc_laps', set())
+                ):
+                    continue
+                lap = e["lap"]
+                if self._y_mode == "gap":
+                    val, gap_is_approx = self._display_gap_meta(e, leader_refs, official_gap_laps, code)
+                    if val is None:
+                        continue
+                else:
+                    if e["time_s"] < 0:
+                        continue
+                    val = e["time_s"]
+                    gap_is_approx = False
+
+                px, py = self._ax.transData.transform((lap, val))
+                dx_px = px - event.x
+                dy_px = py - event.y
+                dist_px2 = dx_px * dx_px + dy_px * dy_px
+                if dist_px2 < best_dist_px2:
+                    best_dist_px2 = dist_px2
+                    best_info = {
+                        "code": code, "lap": lap,
+                        "time_s": e["time_s"], "val": val,
+                        "tyre": e.get("tyre", -1),
+                        "tyre_life": e.get("tyre_life", 0),
+                        "is_approx": self._is_approx_time_entry(e) if self._y_mode == "time" else gap_is_approx,
+                        "is_terminal_lap": bool(e.get("is_terminal_lap")),
+                        "status": e.get("result_status"),
+                    }
+
+        if self._y_mode == "time":
+            for point in terminal_no_time_points:
+                px, py = self._ax.transData.transform((point["lap"], point["val"]))
+                dx_px = px - event.x
+                dy_px = py - event.y
+                dist_px2 = dx_px * dx_px + dy_px * dy_px
+                if dist_px2 < best_dist_px2:
+                    best_dist_px2 = dist_px2
+                    best_info = {
+                        "code": point["code"],
+                        "lap": point["lap"],
+                        "time_s": -1.0,
+                        "val": point["val"],
+                        "tyre": -1,
+                        "tyre_life": 0,
+                        "is_approx": False,
+                        "is_terminal_no_time": True,
+                        "status": point.get("status", "Retired"),
+                    }
+
+        hover_radius_px = 16
+        if best_info and best_dist_px2 <= (hover_radius_px * hover_radius_px):
+            info = best_info
+            colour = self._driver_colors.get(info["code"], _DEFAULT_COLOUR)
+            tyre_name = get_tyre_compound_str(info["tyre"])
+
+            leader_ref = leader_refs.get(info["lap"])
+            if self._y_mode == "gap":
+                val_str = _format_delta(info['val'])
+            else:
+                val_str = _format_laptime(info["time_s"])
+            if info.get("is_approx"):
+                val_str += " (approx)"
+                
+            tyre_life_str = f", {int(info['tyre_life'])} Laps Old" if info.get('tyre_life') else ""
+
+            # Check if this is a session best or personal best lap
+            session_best = getattr(self, '_cached_session_best', float('inf'))
+            is_session_best = (info['time_s'] == session_best)
+            
+            personal_best = getattr(
+                self, '_cached_driver_personal_bests', {}
+            ).get(info['code'], float('inf'))
+            is_personal_best = (info['time_s'] == personal_best and not is_session_best)
+            
+            badge = ""
+            if is_session_best:
+                badge = "  (Session Best Lap Time)"
+            elif is_personal_best:
+                badge = "  (Personal Best Lap Time)"
+
+            extra_lines = []
+            if (
+                self._y_mode == "absolute"
+                and is_personal_best
+                and personal_best < float('inf')
+                and session_best < float('inf')
+            ):
+                pb_gap = personal_best - session_best
+                extra_lines.append(f"Gap to SB: {_format_delta(pb_gap)}")
+
+            if self._y_mode == "gap" and leader_ref is not None:
+                extra_lines.append(
+                    f"Race leader: {leader_ref['code']}"
+                )
+            if info.get("is_terminal_lap") and info.get("status"):
+                extra_lines.append(info["status"])
+
+            if info.get("is_terminal_no_time"):
+                text = (
+                    f"{info['code']}  Lap {info['lap']}\n"
+                    f"Lap time not available\n"
+                    f"({info.get('status', 'Retired')})"
+                )
+            elif self._y_mode == "gap":
+                text = (
+                    f"{info['code']}  Lap {info['lap']}{badge}\n"
+                    f"Gap: {val_str}\n"
+                    f"({tyre_name}{tyre_life_str})"
+                )
+            else:
+                text = (
+                    f"{info['code']}  Lap {info['lap']}{badge}\n"
+                    f"{val_str}  ({tyre_name}{tyre_life_str})"
+                )
+            if extra_lines:
+                text += "\n" + "\n".join(extra_lines)
+
+            # Only redraw if crosshair state actually changed (debounce)
+            new_state = (info["code"], info["lap"])
+            if new_state == self._last_crosshair_state:
+                return
+            self._last_crosshair_state = new_state
+
+            self._annot.xy = (info["lap"], info["val"])
+            self._annot.set_text(text)
+            self._annot.get_bbox_patch().set_edgecolor(colour)
+
+            # Smart offset: place the tooltip, then clamp it back inside the axes
+            x_lo, x_hi = self._ax.get_xlim()
+            y_lo, y_hi = self._ax.get_ylim()
+            x_frac = (info["lap"] - x_lo) / max(x_hi - x_lo, 1)
+            y_frac = (info["val"] - y_lo) / max(y_hi - y_lo, 1)
+            self._annot.set_visible(True)
+            off_x = -140 if x_frac > 0.72 else 15
+            off_y = -35 if y_frac > 0.85 else 15
+            self._annot.xyann = (off_x, off_y)
+
+            try:
+                renderer = self._canvas.renderer
+                axes_bbox = self._ax.get_window_extent(renderer)
+                annot_bbox = self._annot.get_window_extent(renderer)
+                pad = 8
+
+                if annot_bbox.x1 > axes_bbox.x1 - pad:
+                    off_x -= (annot_bbox.x1 - (axes_bbox.x1 - pad))
+                if annot_bbox.x0 < axes_bbox.x0 + pad:
+                    off_x += ((axes_bbox.x0 + pad) - annot_bbox.x0)
+                if annot_bbox.y1 > axes_bbox.y1 - pad:
+                    off_y -= (annot_bbox.y1 - (axes_bbox.y1 - pad))
+                if annot_bbox.y0 < axes_bbox.y0 + pad:
+                    off_y += ((axes_bbox.y0 + pad) - annot_bbox.y0)
+
+                self._annot.xyann = (off_x, off_y)
+            except Exception:
+                pass
+
+            if self._crosshair_v:
+                self._crosshair_v.set_xdata([info["lap"]])
+                self._crosshair_v.set_visible(True)
+            if self._crosshair_h:
+                self._crosshair_h.set_ydata([info["val"]])
+                self._crosshair_h.set_visible(True)
+
+            self._canvas.draw_idle()
+        else:
+            if self._annot.get_visible():
+                self._hide_hover()
+
+    def _is_over_legend(self, event):
+        legend = getattr(self, "_legend_artist", None)
+        if legend is None:
+            return False
+        try:
+            bbox = legend.get_window_extent(self._canvas.renderer)
+        except Exception:
+            return False
+        return bbox.contains(event.x, event.y)
+
+    def _hide_hover(self):
+        if self._annot:
+            self._annot.set_visible(False)
+        if self._crosshair_v:
+            self._crosshair_v.set_visible(False)
+        if self._crosshair_h:
+            self._crosshair_h.set_visible(False)
+        self._last_crosshair_state = None
+        self._canvas.draw_idle()
+
+    def _on_scroll(self, event):
+        """Scroll to zoom, centered on cursor position."""
+        if not event.inaxes:
+            return
+        scale_factor = 0.85 if event.button == "up" else 1.15
+        self._push_undo_state()
+        self._apply_zoom(scale_factor, event.xdata, event.ydata, zoom_x=True, zoom_y=True)
+
+    def _apply_zoom(self, scale_factor, cx, cy, zoom_x=True, zoom_y=True):
+        """Apply zoom centered on (cx, cy) with strict clamping."""
+        ax = self._ax
+        x_lo, x_hi = ax.get_xlim()
+        y_lo, y_hi = ax.get_ylim()
+
+        if zoom_x:
+            new_x_lo = cx - (cx - x_lo) * scale_factor
+            new_x_hi = cx + (x_hi - cx) * scale_factor
+        else:
+            new_x_lo, new_x_hi = x_lo, x_hi
+
+        if zoom_y:
+            new_y_lo = cy - (cy - y_lo) * scale_factor
+            new_y_hi = cy + (y_hi - cy) * scale_factor
+        else:
+            new_y_lo, new_y_hi = y_lo, y_hi
+
+        # Minimum zoom: 3 laps wide, 1.5 seconds tall
+        if zoom_x and (new_x_hi - new_x_lo) < 3:
+            return
+        if zoom_y and self._y_mode == "absolute" and (new_y_hi - new_y_lo) < 1.5:
+            return
+        if zoom_y and self._y_mode == "gap" and (new_y_hi - new_y_lo) < 0.5:
+            return
+
+        # Maximum zoom out: strictly clamp to home, no overshoot
+        if zoom_x and self._home_xlim:
+            hx_lo, hx_hi = self._home_xlim
+            home_xspan = hx_hi - hx_lo
+            if (new_x_hi - new_x_lo) >= home_xspan:
+                new_x_lo, new_x_hi = hx_lo, hx_hi
+            else:
+                # Keep view within home bounds
+                if new_x_lo < hx_lo:
+                    new_x_lo, new_x_hi = hx_lo, hx_lo + (new_x_hi - new_x_lo)
+                if new_x_hi > hx_hi:
+                    new_x_lo, new_x_hi = hx_hi - (new_x_hi - new_x_lo), hx_hi
+        if zoom_y and hasattr(self, '_max_ylim'):
+            hy_lo, hy_hi = self._max_ylim
+            home_yspan = hy_hi - hy_lo
+            if (new_y_hi - new_y_lo) >= home_yspan:
+                new_y_lo, new_y_hi = hy_lo, hy_hi
+            else:
+                if new_y_lo < hy_lo:
+                    new_y_lo, new_y_hi = hy_lo, hy_lo + (new_y_hi - new_y_lo)
+                if new_y_hi > hy_hi:
+                    new_y_lo, new_y_hi = hy_hi - (new_y_hi - new_y_lo), hy_hi
+
+        ax.set_xlim(new_x_lo, new_x_hi)
+        ax.set_ylim(new_y_lo, new_y_hi)
+        self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+        self._canvas.draw_idle()
+
+    def _on_button_press(self, event):
+        """Left-click starts pan; double-left-click resets view."""
+        if event.xdata is None or event.ydata is None:
+            return
+        if event.button == 1:
+            if event.dblclick:
+                self._push_undo_state()
+                self._pan_press_px = None
+                self._pan_active = False
+                self._user_xlim = None
+                self._user_ylim = None
+                self._view_state_by_mode.pop(self._y_mode, None)
+                self._redraw()
+            else:
+                self._push_undo_state()
+                self._pan_press_px = (event.x, event.y)
+                self._pan_origin_xlim = self._ax.get_xlim()
+                self._pan_origin_ylim = self._ax.get_ylim()
+                self._pan_active = True
+
+    def _on_button_release(self, event):
+        """End pan on left-click release."""
+        if event.button == 1:
+            self._pan_press_px = None
+            self._pan_active = False
+
+    def _on_pick(self, event):
+        """Toggle isolation when clicking a driver's legend."""
+        if getattr(event.mouseevent, 'button', None) != 1:
+            return  # Only left clicks
+        if self._pan_active:
+            return  # Don't trigger clicks while dragging
+
+        artist = event.artist
+        # We only allow picking on the legend now to avoid accidental line clicks
+        if artist in getattr(self, '_legend_map', {}):
+            code = self._legend_map[artist]
+            
+            # Toggle isolation
+            if code in self._focused_drivers:
+                self._focused_drivers.remove(code)
+                if not self._focused_drivers:
+                    self._driver_combo.setCurrentText("All Drivers")
+                elif len(self._focused_drivers) == 1:
+                    self._driver_combo.setCurrentText(list(self._focused_drivers)[0])
+                else:
+                    self._driver_combo.setCurrentText("Multiple Drivers")
+            else:
+                self._focused_drivers.add(code)
+                if len(self._focused_drivers) == 1:
+                    self._driver_combo.setCurrentText(code)
+                else:
+                    self._driver_combo.setCurrentText("Multiple Drivers")
+            
+            self._needs_full_redraw = True
+            self._redraw()
+
+    def eventFilter(self, obj, event):
+        """Handle Qt pinch gesture for trackpad zoom."""
+        if event.type() == QEvent.Type.KeyPress:
+            if self._handle_ui_key_event(event):
+                return True
+        if event.type() == QEvent.Type.Gesture:
+            pinch = event.gesture(Qt.GestureType.PinchGesture)
+            if pinch:
+                scale = pinch.scaleFactor()
+                if scale != 1.0:
+                    # Convert pinch to zoom: spread out = zoom in
+                    center = pinch.centerPoint()
+                    # Map widget coords to axes data coords
+                    pos = self._canvas.mapFromGlobal(center.toPoint())
+                    inv = self._ax.transData.inverted()
+                    
+                    # Handle Retina / high-DPI scaling
+                    ratio = self._canvas.devicePixelRatio()
+                    px_x = pos.x() * ratio
+                    px_y = (self._canvas.height() - pos.y()) * ratio
+                    
+                    cx, cy = inv.transform((px_x, px_y))
+                    
+                    # Invert: scale > 1 = spread = zoom in = shrink factor
+                    zoom_factor = 1.0 / scale
+                    self._apply_zoom(zoom_factor, cx, cy)
+                return True
+        return super().eventFilter(obj, event)
+
+    def keyPressEvent(self, event):
+        if self._handle_ui_key_event(event):
+            return
+        super().keyPressEvent(event)
+
+    def _handle_ui_key_event(self, event):
+        key = event.key()
+        if key == Qt.Key.Key_H:
+            self._toggle_help()
+            event.accept()
+            return True
+        if key == Qt.Key.Key_I:
+            self._legend_visible = not self._legend_visible
+            self._needs_full_redraw = True
+            self._redraw()
+            event.accept()
+            return True
+        return False
+
+    def on_connection_status_changed(self, status):
+        if status != "Connected":
+            self._lap_status.setText(status)
+            self._status_sep.setText("")
+            self._time_status.setText("")
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setApplicationName("Lap Time Evolution")
+    window = LapTimeChartWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -26,13 +26,14 @@ matplotlib.use("QtAgg")
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backend_bases import MouseEvent
 
 from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout,
     QLabel, QComboBox, QPushButton, QCheckBox
 )
-from PySide6.QtGui import QFont, QFontMetrics
-from PySide6.QtCore import Qt, QEvent
+from PySide6.QtGui import QFont, QFontMetrics, QCursor
+from PySide6.QtCore import Qt, QEvent, QTimer
 from src.gui.pit_wall_window import PitWallWindow
 from src.lib.tyres import get_tyre_compound_int, get_tyre_compound_str
 
@@ -252,8 +253,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._plot_line_by_code = {}
         self._plot_line_style_by_code = {}
         self._hover_legend_code = None
-        self._shift_held = False
         self._use_native_pinch_zoom = False
+        self._cached_hover_screen_points = []
 
         # Crosshair annotation
         self._annot = None
@@ -278,10 +279,17 @@ class LapTimeChartWindow(PitWallWindow):
         self._redo_stack = []
         self._last_zoom_ts = 0.0
         self._last_pan_draw_ts = 0.0
+        self._last_interaction_ts = 0.0
+        self._pending_live_redraw = False
         # Crosshair debounce
         self._last_crosshair_state = None
+        self._hover_point_key = None
 
         super().__init__()
+
+        self._deferred_redraw_timer = QTimer(self)
+        self._deferred_redraw_timer.setSingleShot(True)
+        self._deferred_redraw_timer.timeout.connect(self._flush_deferred_redraw)
 
         self.setWindowTitle("F1 Race Replay - Lap Time & Gap Evolution")
         self.setGeometry(120, 120, 1000, 600)
@@ -563,8 +571,7 @@ class LapTimeChartWindow(PitWallWindow):
             "</ul>"
             "<h4>Controls</h4>"
             "<ul>"
-            "<li><b>Scroll / Pinch:</b> Zoom the x-axis at the cursor</li>"
-            "<li><b>Shift + Scroll / Pinch:</b> Zoom the y-axis at the cursor</li>"
+            "<li><b>Scroll / Pinch:</b> Zoom at the cursor</li>"
             "<li><b>Left-Click & Drag:</b> Pan the chart</li>"
             "<li><b>Arrow Keys:</b> Pan the view after clicking the chart</li>"
             "<li><b>Undo / Redo:</b> Step backward or forward through chart views</li>"
@@ -667,8 +674,14 @@ class LapTimeChartWindow(PitWallWindow):
         # Redraw when leader crosses a new lap or first data arrival
         if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw:
             self._last_drawn_lap = self._leader_lap
+            force_redraw = self._needs_full_redraw
             self._needs_full_redraw = False
-            self._redraw()
+            if not force_redraw and self._is_interaction_hot():
+                self._pending_live_redraw = True
+                self._schedule_deferred_redraw()
+            else:
+                self._pending_live_redraw = False
+                self._redraw()
 
     def _refresh_driver_list(self, drivers):
         incoming = sorted(drivers.keys())
@@ -764,6 +777,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._ax.set_xlim(snapshot["xlim"])
         self._ax.set_ylim(snapshot["ylim"])
         self._set_user_view(snapshot["xlim"], snapshot["ylim"])
+        self._rebuild_hover_screen_cache()
+        self._refresh_hover_from_cursor()
         self._update_history_buttons()
         self._canvas.draw_idle()
 
@@ -809,6 +824,9 @@ class LapTimeChartWindow(PitWallWindow):
 
     def _redraw(self):
         ax = self._ax
+        self._pending_live_redraw = False
+        previous_hover_legend_code = self._hover_legend_code
+        previous_hover_point_key = self._hover_point_key
         ax.clear()
         self._setup_axes(ax)
         self._annot = None
@@ -1224,6 +1242,7 @@ class LapTimeChartWindow(PitWallWindow):
                         "val": val,
                         "tyre": e.get("tyre", -1),
                         "tyre_life": e.get("tyre_life", 0),
+                        "is_pit_entry": is_pit_entry,
                         "is_approx": self._is_approx_time_entry(e) if self._is_time_mode() else gap_is_approx,
                         "is_terminal_lap": bool(e.get("is_terminal_lap")),
                         "status": e.get("result_status"),
@@ -1316,16 +1335,17 @@ class LapTimeChartWindow(PitWallWindow):
             # Only show when a driver is focused (in All Drivers view,
             # dozens of pit-lap outlier points create noise)
             if pit_laps and focus and is_focused and not pure_pace:
+                pit_marker_y_frac = 0.87 if len(focus) > 1 else 0.95
                 for pl in pit_laps:
                     ax.axvline(
-                        pl, color=colour, alpha=0.3,
-                        linewidth=0.8, linestyle=":",
+                        pl, color=colour, alpha=0.55,
+                        linewidth=1.2, linestyle=":",
                         zorder=zorder - 2,
                     )
                     ax.scatter(
-                        pl, 0.95, marker="x",
-                        color=colour, alpha=0.6, s=35,
-                        zorder=zorder, linewidths=1.5,
+                        pl, pit_marker_y_frac, marker="x",
+                        color=colour, alpha=0.9, s=46,
+                        zorder=zorder, linewidths=1.8,
                         transform=ax.get_xaxis_transform()
                     )
 
@@ -1417,6 +1437,7 @@ class LapTimeChartWindow(PitWallWindow):
                     "val": marker_y,
                     "tyre": -1,
                     "tyre_life": 0,
+                    "is_pit_entry": False,
                     "is_approx": False,
                     "is_terminal_no_time": True,
                     "status": point.get("status", "Retired"),
@@ -1459,6 +1480,9 @@ class LapTimeChartWindow(PitWallWindow):
                     "alpha": 1.0 if leg_text.get_alpha() is None else float(leg_text.get_alpha()),
                 }
             ax.add_artist(leg)
+            if previous_hover_legend_code in self._legend_line_by_code or previous_hover_legend_code in self._legend_text_by_code:
+                self._hover_legend_code = previous_hover_legend_code
+                self._apply_legend_hover_style(previous_hover_legend_code, active=True)
 
         # ── 7. HUD Statistics Legend ──
         if hud_handles:
@@ -1523,7 +1547,11 @@ class LapTimeChartWindow(PitWallWindow):
         if self._user_ylim is not None:
             ax.set_ylim(self._user_ylim)
 
+        self._rebuild_hover_screen_cache()
         self._has_ever_drawn = True
+        self._last_crosshair_state = None
+        if not self._restore_hover_point(previous_hover_point_key):
+            self._refresh_hover_from_cursor()
         self._canvas.draw_idle()
 
     def _draw_stint_bands(self, ax, laps, vals, tyres, zorder, pit_laps=None):
@@ -1624,6 +1652,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._ax.set_xlim(new_x_lo, new_x_hi)
         self._ax.set_ylim(new_y_lo, new_y_hi)
         self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+        self._mark_interaction_activity()
+        self._rebuild_hover_screen_cache()
         self._canvas.draw_idle()
 
     def _reset_view(self):
@@ -1697,6 +1727,8 @@ class LapTimeChartWindow(PitWallWindow):
                 self._ax.set_xlim(new_x_lo, new_x_hi)
                 self._ax.set_ylim(new_y_lo, new_y_hi)
                 self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+                self._mark_interaction_activity()
+                self._rebuild_hover_screen_cache()
                 self._last_pan_draw_ts = now
                 self._canvas.draw_idle()
                 return
@@ -1712,17 +1744,15 @@ class LapTimeChartWindow(PitWallWindow):
                 self._canvas.draw_idle()
             return
 
+        hover_points = getattr(self, "_cached_hover_screen_points", None)
+        if not hover_points:
+            return
+
         # Find nearest data point
         best_dist_px2 = float("inf")
         best_info = None
-
-        hover_candidates = getattr(self, "_cached_hover_candidates", None)
-        if not hover_candidates:
-            return
-
         leader_refs = getattr(self, '_cached_leader_refs', {})
-        for info in hover_candidates:
-            px, py = self._ax.transData.transform((info["lap"], info["val"]))
+        for px, py, info in hover_points:
             dx_px = px - event.x
             dy_px = py - event.y
             dist_px2 = dx_px * dx_px + dy_px * dy_px
@@ -1732,119 +1762,7 @@ class LapTimeChartWindow(PitWallWindow):
 
         hover_radius_px = 16
         if best_info and best_dist_px2 <= (hover_radius_px * hover_radius_px):
-            info = best_info
-            colour = self._driver_colors.get(info["code"], _DEFAULT_COLOUR)
-            tyre_name = get_tyre_compound_str(info["tyre"])
-
-            leader_ref = leader_refs.get(info["lap"])
-            if self._is_gap_mode():
-                val_str = _format_delta(info['val'])
-            else:
-                val_str = _format_laptime(info["time_s"])
-            if info.get("is_approx"):
-                val_str += " (approx)"
-                
-            tyre_life_str = f", {int(info['tyre_life'])} Laps Old" if info.get('tyre_life') else ""
-
-            # Check if this is a session best or personal best lap
-            session_best = getattr(self, '_cached_session_best', float('inf'))
-            is_session_best = (info['time_s'] == session_best)
-            
-            personal_best = getattr(
-                self, '_cached_driver_personal_bests', {}
-            ).get(info['code'], float('inf'))
-            is_personal_best = (info['time_s'] == personal_best and not is_session_best)
-            
-            badge = ""
-            if is_session_best:
-                badge = "  (Session Best Lap Time)"
-            elif is_personal_best:
-                badge = "  (Personal Best Lap Time)"
-
-            extra_lines = []
-            if (
-                self._is_time_mode()
-                and is_personal_best
-                and personal_best < float('inf')
-                and session_best < float('inf')
-            ):
-                pb_gap = personal_best - session_best
-                extra_lines.append(f"Gap to SB: {_format_delta(pb_gap)}")
-
-            if self._is_gap_mode() and leader_ref is not None:
-                extra_lines.append(
-                    f"Race leader: {leader_ref['code']}"
-                )
-            if info.get("is_terminal_lap") and info.get("status"):
-                extra_lines.append(info["status"])
-
-            if info.get("is_terminal_no_time"):
-                text = (
-                    f"{info['code']}  Lap {info['lap']}\n"
-                    f"Lap time not available\n"
-                    f"({info.get('status', 'Retired')})"
-                )
-            elif self._is_gap_mode():
-                text = (
-                    f"{info['code']}  Lap {info['lap']}{badge}\n"
-                    f"Gap: {val_str}\n"
-                    f"({tyre_name}{tyre_life_str})"
-                )
-            else:
-                text = (
-                    f"{info['code']}  Lap {info['lap']}{badge}\n"
-                    f"{val_str}  ({tyre_name}{tyre_life_str})"
-                )
-            if extra_lines:
-                text += "\n" + "\n".join(extra_lines)
-
-            # Only redraw if crosshair state actually changed (debounce)
-            new_state = (info["code"], info["lap"])
-            if new_state == self._last_crosshair_state:
-                return
-            self._last_crosshair_state = new_state
-
-            self._annot.xy = (info["lap"], info["val"])
-            self._annot.set_text(text)
-            self._annot.get_bbox_patch().set_edgecolor(colour)
-
-            # Smart offset: place the tooltip, then clamp it back inside the axes
-            x_lo, x_hi = self._ax.get_xlim()
-            y_lo, y_hi = self._ax.get_ylim()
-            x_frac = (info["lap"] - x_lo) / max(x_hi - x_lo, 1)
-            y_frac = (info["val"] - y_lo) / max(y_hi - y_lo, 1)
-            self._annot.set_visible(True)
-            off_x = -140 if x_frac > 0.72 else 15
-            off_y = -35 if y_frac > 0.85 else 15
-            self._annot.xyann = (off_x, off_y)
-
-            try:
-                renderer = self._canvas.renderer
-                axes_bbox = self._ax.get_window_extent(renderer)
-                annot_bbox = self._annot.get_window_extent(renderer)
-                pad = 8
-
-                if annot_bbox.x1 > axes_bbox.x1 - pad:
-                    off_x -= (annot_bbox.x1 - (axes_bbox.x1 - pad))
-                if annot_bbox.x0 < axes_bbox.x0 + pad:
-                    off_x += ((axes_bbox.x0 + pad) - annot_bbox.x0)
-                if annot_bbox.y1 > axes_bbox.y1 - pad:
-                    off_y -= (annot_bbox.y1 - (axes_bbox.y1 - pad))
-                if annot_bbox.y0 < axes_bbox.y0 + pad:
-                    off_y += ((axes_bbox.y0 + pad) - annot_bbox.y0)
-
-                self._annot.xyann = (off_x, off_y)
-            except Exception:
-                pass
-
-            if self._crosshair_v:
-                self._crosshair_v.set_xdata([info["lap"]])
-                self._crosshair_v.set_visible(True)
-            if self._crosshair_h:
-                self._crosshair_h.set_ydata([info["val"]])
-                self._crosshair_h.set_visible(True)
-
-            self._canvas.draw_idle()
+            self._show_hover_info(best_info, leader_refs)
         else:
             if self._annot.get_visible():
                 self._hide_hover()
@@ -1923,6 +1841,138 @@ class LapTimeChartWindow(PitWallWindow):
                 legend_text.set_alpha(legend_text_style["alpha"])
                 legend_text.set_fontweight(legend_text_style["fontweight"])
 
+    def _find_hover_info_by_key(self, hover_key):
+        if not hover_key:
+            return None
+        hover_candidates = getattr(self, "_cached_hover_candidates", None) or []
+        code, lap = hover_key
+        for info in hover_candidates:
+            if info.get("code") == code and info.get("lap") == lap:
+                return info
+        return None
+
+    def _restore_hover_point(self, hover_key):
+        info = self._find_hover_info_by_key(hover_key)
+        if info is None:
+            return False
+        self._show_hover_info(info, getattr(self, "_cached_leader_refs", {}))
+        return True
+
+    def _show_hover_info(self, info, leader_refs):
+        if info is None or self._annot is None:
+            return
+
+        colour = self._driver_colors.get(info["code"], _DEFAULT_COLOUR)
+        tyre_name = get_tyre_compound_str(info["tyre"])
+
+        leader_ref = leader_refs.get(info["lap"])
+        if self._is_gap_mode():
+            val_str = _format_delta(info['val'])
+        else:
+            val_str = _format_laptime(info["time_s"])
+        if info.get("is_approx"):
+            val_str += " (approx)"
+
+        tyre_life_str = f", {int(info['tyre_life'])} Laps Old" if info.get('tyre_life') else ""
+
+        session_best = getattr(self, '_cached_session_best', float('inf'))
+        is_session_best = (info['time_s'] == session_best)
+
+        personal_best = getattr(
+            self, '_cached_driver_personal_bests', {}
+        ).get(info['code'], float('inf'))
+        is_personal_best = (info['time_s'] == personal_best and not is_session_best)
+
+        badge = ""
+        if is_session_best:
+            badge = "  (Session Best Lap Time)"
+        elif is_personal_best:
+            badge = "  (Personal Best Lap Time)"
+
+        extra_lines = []
+        if (
+            self._is_time_mode()
+            and is_personal_best
+            and personal_best < float('inf')
+            and session_best < float('inf')
+        ):
+            pb_gap = personal_best - session_best
+            extra_lines.append(f"Gap to SB: {_format_delta(pb_gap)}")
+
+        if self._is_gap_mode() and leader_ref is not None:
+            extra_lines.append(f"Race leader: {leader_ref['code']}")
+        if info.get("is_pit_entry"):
+            extra_lines.append("Pit stop")
+        if info.get("is_terminal_lap") and info.get("status"):
+            extra_lines.append(info["status"])
+
+        if info.get("is_terminal_no_time"):
+            text = (
+                f"{info['code']}  Lap {info['lap']}\n"
+                f"Lap time not available\n"
+                f"({info.get('status', 'Retired')})"
+            )
+        elif self._is_gap_mode():
+            text = (
+                f"{info['code']}  Lap {info['lap']}{badge}\n"
+                f"Gap: {val_str}\n"
+                f"({tyre_name}{tyre_life_str})"
+            )
+        else:
+            text = (
+                f"{info['code']}  Lap {info['lap']}{badge}\n"
+                f"{val_str}  ({tyre_name}{tyre_life_str})"
+            )
+        if extra_lines:
+            text += "\n" + "\n".join(extra_lines)
+
+        new_state = (info["code"], info["lap"])
+        if new_state == self._last_crosshair_state and self._annot.get_visible():
+            return
+        self._last_crosshair_state = new_state
+        self._hover_point_key = new_state
+
+        self._annot.xy = (info["lap"], info["val"])
+        self._annot.set_text(text)
+        self._annot.get_bbox_patch().set_edgecolor(colour)
+
+        x_lo, x_hi = self._ax.get_xlim()
+        y_lo, y_hi = self._ax.get_ylim()
+        x_frac = (info["lap"] - x_lo) / max(x_hi - x_lo, 1)
+        y_frac = (info["val"] - y_lo) / max(y_hi - y_lo, 1)
+        self._annot.set_visible(True)
+        off_x = -140 if x_frac > 0.72 else 15
+        off_y = -35 if y_frac > 0.85 else 15
+        self._annot.xyann = (off_x, off_y)
+
+        try:
+            renderer = self._canvas.renderer
+            axes_bbox = self._ax.get_window_extent(renderer)
+            annot_bbox = self._annot.get_window_extent(renderer)
+            pad = 8
+
+            if annot_bbox.x1 > axes_bbox.x1 - pad:
+                off_x -= (annot_bbox.x1 - (axes_bbox.x1 - pad))
+            if annot_bbox.x0 < axes_bbox.x0 + pad:
+                off_x += ((axes_bbox.x0 + pad) - annot_bbox.x0)
+            if annot_bbox.y1 > axes_bbox.y1 - pad:
+                off_y -= (annot_bbox.y1 - (axes_bbox.y1 - pad))
+            if annot_bbox.y0 < axes_bbox.y0 + pad:
+                off_y += ((axes_bbox.y0 + pad) - annot_bbox.y0)
+
+            self._annot.xyann = (off_x, off_y)
+        except Exception:
+            pass
+
+        if self._crosshair_v:
+            self._crosshair_v.set_xdata([info["lap"]])
+            self._crosshair_v.set_visible(True)
+        if self._crosshair_h:
+            self._crosshair_h.set_ydata([info["val"]])
+            self._crosshair_h.set_visible(True)
+
+        self._canvas.draw_idle()
+
     def _hide_hover(self):
         if self._annot:
             self._annot.set_visible(False)
@@ -1931,30 +1981,59 @@ class LapTimeChartWindow(PitWallWindow):
         if self._crosshair_h:
             self._crosshair_h.set_visible(False)
         self._last_crosshair_state = None
+        self._hover_point_key = None
         self._canvas.draw_idle()
 
-    def _update_modifier_latch(self, event, pressed):
-        if event.key() == Qt.Key.Key_Shift:
-            self._shift_held = pressed
-
-    def _zoom_axes_for_input(self, event_key=None, modifiers=None):
-        shift_active = self._shift_held
-        current_modifiers = Qt.KeyboardModifier.NoModifier
-        try:
-            current_modifiers = QApplication.queryKeyboardModifiers()
-        except Exception:
+    def _rebuild_hover_screen_cache(self):
+        hover_candidates = getattr(self, "_cached_hover_candidates", None)
+        if not hover_candidates or not hasattr(self, "_ax"):
+            self._cached_hover_screen_points = []
+            return
+        transform = self._ax.transData.transform
+        screen_points = []
+        for info in hover_candidates:
             try:
-                current_modifiers = QApplication.keyboardModifiers()
+                px, py = transform((info["lap"], info["val"]))
             except Exception:
-                current_modifiers = Qt.KeyboardModifier.NoModifier
-        combined_modifiers = current_modifiers
-        if modifiers is not None:
-            combined_modifiers = combined_modifiers | modifiers
-        if combined_modifiers & Qt.KeyboardModifier.ShiftModifier:
-            shift_active = True
-        if isinstance(event_key, str) and "shift" in event_key.lower():
-            shift_active = True
-        return (not shift_active, shift_active)
+                continue
+            screen_points.append((float(px), float(py), info))
+        self._cached_hover_screen_points = screen_points
+
+    def _refresh_hover_from_cursor(self):
+        if not hasattr(self, "_canvas") or not getattr(self, "_has_ever_drawn", False):
+            return
+        local_pos = self._canvas.mapFromGlobal(QCursor.pos())
+        if not self._canvas.rect().contains(local_pos):
+            return
+        ratio = self._canvas.devicePixelRatio()
+        px_x = float(local_pos.x()) * ratio
+        px_y = (self._canvas.height() - float(local_pos.y())) * ratio
+        event = MouseEvent("motion_notify_event", self._canvas, px_x, px_y)
+        self._on_mouse_move(event)
+
+    def _mark_interaction_activity(self):
+        self._last_interaction_ts = time.monotonic()
+
+    def _is_interaction_hot(self):
+        now = time.monotonic()
+        latest = max(self._last_interaction_ts, self._last_zoom_ts)
+        return (
+            self._pan_press_px is not None
+            or self._pan_active
+            or (latest > 0.0 and (now - latest) < 0.18)
+        )
+
+    def _schedule_deferred_redraw(self):
+        self._deferred_redraw_timer.start(140)
+
+    def _flush_deferred_redraw(self):
+        if not self._pending_live_redraw:
+            return
+        if self._is_interaction_hot():
+            self._schedule_deferred_redraw()
+            return
+        self._pending_live_redraw = False
+        self._redraw()
 
     def _widget_pos_to_data(self, pointf):
         if pointf is None:
@@ -1974,14 +2053,11 @@ class LapTimeChartWindow(PitWallWindow):
             self._push_undo_state()
         self._last_zoom_ts = now
 
-    def _apply_zoom_from_input(self, scale_factor, cx, cy, modifiers=None, event_key=None):
+    def _apply_zoom_from_input(self, scale_factor, cx, cy):
         if cx is None or cy is None or scale_factor is None or scale_factor <= 0:
             return
-        zoom_x, zoom_y = self._zoom_axes_for_input(event_key=event_key, modifiers=modifiers)
-        self._apply_zoom(
-            scale_factor, cx, cy,
-            zoom_x=zoom_x, zoom_y=zoom_y,
-        )
+        self._mark_interaction_activity()
+        self._apply_zoom(scale_factor, cx, cy)
         self._last_zoom_ts = time.monotonic()
 
     def _smooth_zoom_factor(self, scale_factor, *, deadband=0.006, clamp=0.12):
@@ -2014,34 +2090,27 @@ class LapTimeChartWindow(PitWallWindow):
             raw = (1.0 / base_zoom) ** steps
         return self._smooth_zoom_factor(raw, deadband=0.004, clamp=0.16)
 
-    def _apply_zoom(self, scale_factor, cx, cy, zoom_x=True, zoom_y=True):
+    def _apply_zoom(self, scale_factor, cx, cy):
         """Apply zoom centered on (cx, cy) with strict clamping."""
         ax = self._ax
         x_lo, x_hi = ax.get_xlim()
         y_lo, y_hi = ax.get_ylim()
 
-        if zoom_x:
-            new_x_lo = cx - (cx - x_lo) * scale_factor
-            new_x_hi = cx + (x_hi - cx) * scale_factor
-        else:
-            new_x_lo, new_x_hi = x_lo, x_hi
-
-        if zoom_y:
-            new_y_lo = cy - (cy - y_lo) * scale_factor
-            new_y_hi = cy + (y_hi - cy) * scale_factor
-        else:
-            new_y_lo, new_y_hi = y_lo, y_hi
+        new_x_lo = cx - (cx - x_lo) * scale_factor
+        new_x_hi = cx + (x_hi - cx) * scale_factor
+        new_y_lo = cy - (cy - y_lo) * scale_factor
+        new_y_hi = cy + (y_hi - cy) * scale_factor
 
         # Minimum zoom: 3 laps wide, 1.5 seconds tall
-        if zoom_x and (new_x_hi - new_x_lo) < 3:
+        if (new_x_hi - new_x_lo) < 3:
             return
-        if zoom_y and self._is_time_mode() and (new_y_hi - new_y_lo) < 1.5:
+        if self._is_time_mode() and (new_y_hi - new_y_lo) < 1.5:
             return
-        if zoom_y and self._is_gap_mode() and (new_y_hi - new_y_lo) < 0.5:
+        if self._is_gap_mode() and (new_y_hi - new_y_lo) < 0.5:
             return
 
         # Maximum zoom out: strictly clamp to home, no overshoot
-        if zoom_x and self._home_xlim:
+        if self._home_xlim:
             hx_lo, hx_hi = self._home_xlim
             home_xspan = hx_hi - hx_lo
             if (new_x_hi - new_x_lo) >= home_xspan:
@@ -2052,7 +2121,7 @@ class LapTimeChartWindow(PitWallWindow):
                     new_x_lo, new_x_hi = hx_lo, hx_lo + (new_x_hi - new_x_lo)
                 if new_x_hi > hx_hi:
                     new_x_lo, new_x_hi = hx_hi - (new_x_hi - new_x_lo), hx_hi
-        if zoom_y and hasattr(self, '_max_ylim'):
+        if hasattr(self, '_max_ylim'):
             hy_lo, hy_hi = self._max_ylim
             home_yspan = hy_hi - hy_lo
             if (new_y_hi - new_y_lo) >= home_yspan:
@@ -2066,6 +2135,7 @@ class LapTimeChartWindow(PitWallWindow):
         ax.set_xlim(new_x_lo, new_x_hi)
         ax.set_ylim(new_y_lo, new_y_hi)
         self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+        self._rebuild_hover_screen_cache()
         self._canvas.draw_idle()
 
     def _on_button_press(self, event):
@@ -2078,6 +2148,7 @@ class LapTimeChartWindow(PitWallWindow):
                 self._push_undo_state()
                 self._reset_view()
             else:
+                self._mark_interaction_activity()
                 self._pan_press_px = (event.x, event.y)
                 self._pan_origin_xlim = self._ax.get_xlim()
                 self._pan_origin_ylim = self._ax.get_ylim()
@@ -2102,22 +2173,27 @@ class LapTimeChartWindow(PitWallWindow):
         # We only allow picking on the legend now to avoid accidental line clicks
         if artist in getattr(self, '_legend_map', {}):
             code = self._legend_map[artist]
+            self._hover_legend_code = code
             
             # Toggle isolation
             if code in self._focused_drivers:
                 self._focused_drivers.remove(code)
                 if not self._focused_drivers:
-                    self._driver_combo.setCurrentText("All Drivers")
+                    combo_text = "All Drivers"
                 elif len(self._focused_drivers) == 1:
-                    self._driver_combo.setCurrentText(list(self._focused_drivers)[0])
+                    combo_text = next(iter(self._focused_drivers))
                 else:
-                    self._driver_combo.setCurrentText("Multiple Drivers")
+                    combo_text = "Multiple Drivers"
             else:
                 self._focused_drivers.add(code)
                 if len(self._focused_drivers) == 1:
-                    self._driver_combo.setCurrentText(code)
+                    combo_text = code
                 else:
-                    self._driver_combo.setCurrentText("Multiple Drivers")
+                    combo_text = "Multiple Drivers"
+
+            self._driver_combo.blockSignals(True)
+            self._driver_combo.setCurrentText(combo_text)
+            self._driver_combo.blockSignals(False)
             
             self._needs_full_redraw = True
             self._redraw()
@@ -2125,18 +2201,15 @@ class LapTimeChartWindow(PitWallWindow):
     def eventFilter(self, obj, event):
         """Handle Qt wheel and gesture zoom directly for consistent UX."""
         if event.type() == QEvent.Type.KeyPress:
-            self._update_modifier_latch(event, True)
             if self._handle_ui_key_event(event):
                 return True
-        if event.type() == QEvent.Type.KeyRelease:
-            self._update_modifier_latch(event, False)
         if event.type() == QEvent.Type.Wheel and obj is self._canvas:
             cx, cy = self._widget_pos_to_data(event.position())
             if cx is None or cy is None:
                 return False
             self._begin_zoom_gesture()
             scale_factor = self._scale_factor_from_wheel_event(event)
-            self._apply_zoom_from_input(scale_factor, cx, cy, modifiers=event.modifiers())
+            self._apply_zoom_from_input(scale_factor, cx, cy)
             return True
         if self._use_native_pinch_zoom and event.type() == QEvent.Type.NativeGesture and obj is self._canvas:
             gesture_type = event.gestureType()
@@ -2155,7 +2228,7 @@ class LapTimeChartWindow(PitWallWindow):
                 if scale_delta <= 0.0:
                     return True
                 zoom_factor = self._smooth_zoom_factor(1.0 / scale_delta, deadband=0.0035, clamp=0.10)
-                self._apply_zoom_from_input(zoom_factor, cx, cy, modifiers=event.modifiers())
+                self._apply_zoom_from_input(zoom_factor, cx, cy)
                 return True
         if (not self._use_native_pinch_zoom) and event.type() == QEvent.Type.Gesture:
             pinch = event.gesture(Qt.GestureType.PinchGesture)
@@ -2178,13 +2251,11 @@ class LapTimeChartWindow(PitWallWindow):
         return super().eventFilter(obj, event)
 
     def keyPressEvent(self, event):
-        self._update_modifier_latch(event, True)
         if self._handle_ui_key_event(event):
             return
         super().keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
-        self._update_modifier_latch(event, False)
         super().keyReleaseEvent(event)
 
     def _handle_ui_key_event(self, event):

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -238,24 +238,11 @@ def _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps):
     )
 
 
-def _legend_state_slot(entry):
-    if not entry:
-        return ""
-    if entry.get("is_terminal_lap") and entry.get("result_status"):
-        return "RET"
-    if _entry_is_pit_entry(entry):
-        return "PITS"
-    tyre = entry.get("tyre", -1)
-    tyre_name = get_tyre_compound_str(tyre)
-    if not tyre_name:
-        return ""
-    tyre_char = tyre_name[0].upper()
-    tyre_life = entry.get("tyre_life")
-    if isinstance(tyre_life, (int, float)) and tyre_life >= 0:
-        tyre_life_int = int(tyre_life)
-        if tyre_life_int > 0:
-            return f"{tyre_char}{tyre_life_int:02d}"
-    return tyre_char
+def _terminal_status_display_text(status):
+    status_text = str(status or "").strip()
+    if not status_text or status_text.lower() == "retired":
+        return "Retired due to DNF"
+    return status_text
 
 
 class LapTimeChartWindow(PitWallWindow):
@@ -270,6 +257,7 @@ class LapTimeChartWindow(PitWallWindow):
         self._known_drivers = []
         self._total_laps = 0
         self._leader_lap = 0
+        self._current_time_s = None
         self._last_drawn_lap = 0
         self._needs_full_redraw = True
         self._focused_drivers = set()   # set of codes
@@ -318,6 +306,7 @@ class LapTimeChartWindow(PitWallWindow):
         # Crosshair debounce
         self._last_crosshair_state = None
         self._hover_point_key = None
+        self._last_rendered_terminal_signature = ()
 
         super().__init__()
 
@@ -339,6 +328,51 @@ class LapTimeChartWindow(PitWallWindow):
                 border: none;
             }
         """)
+
+    def _terminal_entry_visibility_time_s(self, entry):
+        if not entry or not entry.get("is_terminal_lap"):
+            return None
+        for key in (
+            "terminal_event_time_s",
+            "replay_line_time_s",
+            "replay_end_time_s",
+            "line_time_s",
+            "end_time_s",
+        ):
+            value = entry.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+        return None
+
+    def _is_terminal_entry_visible(self, entry, include_final=False):
+        if not entry or not entry.get("is_terminal_lap"):
+            return False
+        if include_final:
+            return True
+        visible_at_s = self._terminal_entry_visibility_time_s(entry)
+        if visible_at_s is not None and isinstance(self._current_time_s, (int, float)):
+            return self._current_time_s >= visible_at_s
+        lap = entry.get("lap")
+        if isinstance(lap, (int, float)):
+            return self._leader_lap > int(lap)
+        return False
+
+    def _terminal_visibility_signature(self):
+        if not self._lap_times:
+            return ()
+        include_final = bool(self._total_laps and self._leader_lap >= self._total_laps)
+        visible = []
+        for code, entries in self._lap_times.items():
+            for entry in entries:
+                if self._is_terminal_entry_visible(entry, include_final=include_final):
+                    visible.append((code, int(entry.get("lap", -1))))
+        return tuple(sorted(visible))
+
+    def _completed_lap_cutoff(self):
+        include_final = bool(self._total_laps and self._leader_lap >= self._total_laps)
+        if include_final:
+            return max(0, int(self._leader_lap))
+        return max(0, int(self._leader_lap) - 1)
         
 
     def resizeEvent(self, event):
@@ -687,6 +721,9 @@ class LapTimeChartWindow(PitWallWindow):
             if tl:
                 self._total_laps = int(tl)
                 self._reserve_status_width()
+            new_time_s = sd.get("time_s", self._current_time_s)
+            if isinstance(new_time_s, (int, float)):
+                self._current_time_s = float(new_time_s)
             new_leader_lap = sd.get("lap", self._leader_lap)
             if isinstance(new_leader_lap, (int, float)):
                 self._leader_lap = int(new_leader_lap)
@@ -701,6 +738,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._user_xlim = None
             self._user_ylim = None
             self._view_state_by_mode.clear()
+            self._last_rendered_terminal_signature = ()
 
         # Ingest pre-computed data from server
         if "lap_times" in data:
@@ -717,8 +755,13 @@ class LapTimeChartWindow(PitWallWindow):
         # Update driver list
         self._refresh_driver_list(drivers)
 
-        # Redraw when leader crosses a new lap or first data arrival
-        if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw:
+        terminal_visibility_changed = (
+            self._terminal_visibility_signature() != self._last_rendered_terminal_signature
+        )
+
+        # Redraw when leader crosses a new lap, terminal state becomes visible,
+        # or the chart needs a full rebuild.
+        if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw or terminal_visibility_changed:
             self._last_drawn_lap = self._leader_lap
             force_redraw = self._needs_full_redraw
             self._needs_full_redraw = False
@@ -894,20 +937,23 @@ class LapTimeChartWindow(PitWallWindow):
 
         focus = self._focused_drivers
 
-        # Show completed laps only during replay, but include the final lap once
-        # the race has actually finished.
+        # Show completed laps during replay. Terminal no-time laps become visible
+        # only once the replay has actually reached their event timestamp.
         visible_data = {}
         lap_cutoff = self._leader_lap
         include_final_lap = self._total_laps and self._leader_lap >= self._total_laps
+        completed_lap_cutoff = self._completed_lap_cutoff()
         for code, entries in self._lap_times.items():
-            terminal_lap = next((e["lap"] for e in entries if e.get("is_terminal_lap")), None)
-            effective_cutoff = lap_cutoff
-            if terminal_lap is not None:
-                effective_cutoff = min(effective_cutoff, terminal_lap)
             if include_final_lap:
-                visible = [e for e in entries if e["lap"] <= effective_cutoff]
+                visible = [e for e in entries if e["lap"] <= lap_cutoff or e.get("is_terminal_lap")]
             else:
-                visible = [e for e in entries if e["lap"] < effective_cutoff or (e.get("is_terminal_lap") and e["lap"] == effective_cutoff)]
+                visible = []
+                for entry in entries:
+                    if entry.get("is_terminal_lap"):
+                        if self._is_terminal_entry_visible(entry, include_final=False):
+                            visible.append(entry)
+                    elif entry["lap"] < lap_cutoff:
+                        visible.append(entry)
             if visible:
                 visible_data[code] = visible
 
@@ -923,9 +969,9 @@ class LapTimeChartWindow(PitWallWindow):
         # to prevent label overlap (e.g. VSC → SC on consecutive laps).
         merged_zones = []
         for sp in self._status_laps:
-            if sp["start_lap"] > self._leader_lap:
+            if sp["start_lap"] > completed_lap_cutoff:
                 continue
-            end_lap = min(sp["end_lap"], self._leader_lap)
+            end_lap = min(sp["end_lap"], completed_lap_cutoff)
             status = sp["status"]
             if status == "4":
                 colour, label = _SC_COLOUR, "SC"
@@ -1129,13 +1175,13 @@ class LapTimeChartWindow(PitWallWindow):
         self._cached_gap_adjustments = gap_adjustments
         self._cached_gap_overrides = gap_overrides
         self._cached_gap_suppressed_laps = gap_suppressed_laps
-        self._cached_terminal_no_time_points = []
+        self._cached_terminal_marker_points = []
         self._cached_hover_candidates = []
                         
         for sp in self._status_laps:
-            if sp["start_lap"] > self._leader_lap:
+            if sp["start_lap"] > completed_lap_cutoff:
                 continue
-            end_lap = min(sp["end_lap"], self._leader_lap)
+            end_lap = min(sp["end_lap"], completed_lap_cutoff)
             status = sp["status"]
             if status not in ("4", "5", "6", "7"):
                 continue
@@ -1181,7 +1227,6 @@ class LapTimeChartWindow(PitWallWindow):
         driver_stints_text = {}
         display_y_vals = []
         all_axis_y_vals = []
-        legend_slot_by_code = {}
 
         session_best = float("inf")
         for code_sb, entries in visible_data.items():
@@ -1194,8 +1239,6 @@ class LapTimeChartWindow(PitWallWindow):
 
         for code, entries in visible_data.items():
             colour = self._driver_colors.get(code, _DEFAULT_COLOUR)
-            if entries:
-                legend_slot_by_code[code] = _legend_state_slot(entries[-1])
 
             if focus:
                 is_focused = code in focus
@@ -1212,7 +1255,7 @@ class LapTimeChartWindow(PitWallWindow):
             clean_laps, clean_vals, clean_time_s, clean_tyres = [], [], [], []
             pit_laps = []
             all_laps, all_vals, all_markers, all_marker_colours = [], [], [], []
-            terminal_no_time_laps = []
+            terminal_marker_entries = []
             
             drv_clean_times = [
                 e["time_s"] for e in entries
@@ -1232,18 +1275,37 @@ class LapTimeChartWindow(PitWallWindow):
                 if pure_pace and (lap in sc_vsc_laps or is_pit_affected or is_out_lap or is_outlier):
                     continue
 
+                terminal_generated_entry = bool(e.get("is_terminal_lap") and raw_time < 0)
                 gap_is_approx = False
                 if self._is_gap_mode():
                     gap_val, gap_is_approx = self._display_gap_meta(e, leader_refs, code)
+                    if terminal_generated_entry:
+                        terminal_marker_entries.append({
+                            "entry": e,
+                            "prev_lap": all_laps[-1] if all_laps else None,
+                            "prev_val": all_vals[-1] if all_vals else None,
+                            "display_val": gap_val,
+                        })
+                        if is_pit_entry:
+                            pit_laps.append(lap)
+                        continue
                     val = gap_val
                     if val is None:
                         if is_pit_entry:
                             pit_laps.append(lap)
                         continue
                 else:
+                    if terminal_generated_entry:
+                        terminal_marker_entries.append({
+                            "entry": e,
+                            "prev_lap": all_laps[-1] if all_laps else None,
+                            "prev_val": all_vals[-1] if all_vals else None,
+                            "display_val": None,
+                        })
+                        if is_pit_entry:
+                            pit_laps.append(lap)
+                        continue
                     if raw_time < 0:
-                        if e.get("is_terminal_lap"):
-                            terminal_no_time_laps.append(lap)
                         if is_pit_entry:
                             pit_laps.append(lap)
                         continue
@@ -1382,23 +1444,23 @@ class LapTimeChartWindow(PitWallWindow):
                         transform=ax.get_xaxis_transform()
                     )
 
-            if terminal_no_time_laps and focus and is_focused and self._is_time_mode():
-                for pl in terminal_no_time_laps:
-                    status_text = next(
-                        (
-                            e.get("result_status", "Retired")
-                            for e in entries
-                            if e.get("lap") == pl and e.get("is_terminal_lap")
-                        ),
-                        "Retired",
-                    )
-                    self._cached_terminal_no_time_points.append({
+            if terminal_marker_entries and focus and is_focused and not pure_pace:
+                for item in terminal_marker_entries:
+                    e = item["entry"]
+                    self._cached_terminal_marker_points.append({
                         "code": code,
-                        "lap": pl,
+                        "lap": e["lap"],
                         "colour": colour,
                         "alpha": alpha,
                         "zorder": zorder + 2,
-                        "status": status_text,
+                        "line_width": lw,
+                        "prev_lap": item.get("prev_lap"),
+                        "prev_val": item.get("prev_val"),
+                        "display_val": item.get("display_val"),
+                        "tyre": e.get("tyre", -1),
+                        "tyre_life": e.get("tyre_life", 0),
+                        "status": _terminal_status_display_text(e.get("result_status")),
+                        "is_pit_entry": bool(e.get("is_pit_entry")),
                     })
 
         # ── 4b. HUD Statistics (prepared for drawing at the end) ──
@@ -1445,14 +1507,27 @@ class LapTimeChartWindow(PitWallWindow):
                 pad = max(2.0, (y_max_display - y_min_display) * 0.06)
                 ax.set_ylim(y_min_display - pad, y_max_display + pad)
 
-        if self._cached_terminal_no_time_points and self._is_time_mode():
+        if self._cached_terminal_marker_points:
             y_lo, y_hi = ax.get_ylim()
             span = max(y_hi - y_lo, 1.0)
             marker_y = y_hi - span * 0.045
-            for point in self._cached_terminal_no_time_points:
-                point["val"] = marker_y
+            for point in self._cached_terminal_marker_points:
+                draw_val = point.get("display_val")
+                if draw_val is None:
+                    draw_val = marker_y
+                point["val"] = draw_val
+                if point.get("prev_lap") is not None and point.get("prev_val") is not None:
+                    ax.plot(
+                        [point["prev_lap"], point["lap"]],
+                        [point["prev_val"], draw_val],
+                        color=point["colour"],
+                        alpha=min(1.0, point["alpha"] * 0.95),
+                        linewidth=max(1.0, point.get("line_width", 1.0)),
+                        linestyle="-",
+                        zorder=point["zorder"] - 1,
+                    )
                 ax.scatter(
-                    point["lap"], marker_y,
+                    point["lap"], draw_val,
                     marker="o", facecolors=_BG, edgecolors=point["colour"],
                     alpha=point["alpha"], s=46, linewidths=1.4,
                     zorder=point["zorder"],
@@ -1461,13 +1536,13 @@ class LapTimeChartWindow(PitWallWindow):
                     "code": point["code"],
                     "lap": point["lap"],
                     "time_s": -1.0,
-                    "val": marker_y,
-                    "tyre": -1,
-                    "tyre_life": 0,
-                    "is_pit_entry": False,
+                    "val": draw_val,
+                    "tyre": point.get("tyre", -1),
+                    "tyre_life": point.get("tyre_life", 0),
+                    "is_pit_entry": point.get("is_pit_entry", False),
                     "is_approx": False,
                     "is_terminal_no_time": True,
-                    "status": point.get("status", "Retired"),
+                    "status": point.get("status", "Retired due to DNF"),
                 })
 
         # X-axis
@@ -1480,12 +1555,8 @@ class LapTimeChartWindow(PitWallWindow):
         # ── 6. Interactive legend (click to isolate) ──
         handles, labels = ax.get_legend_handles_labels()
         if handles and self._legend_visible:
-            display_labels = []
-            for code in labels:
-                indicator = legend_slot_by_code.get(code, "")
-                display_labels.append(f"{code:<3}  {indicator:<4}")
             leg = ax.legend(
-                handles, display_labels,
+                handles, labels,
                 loc="upper right", fontsize=7, framealpha=0.6,
                 facecolor=_BG, edgecolor="#555555", labelcolor=_TEXT,
                 ncol=2 if len(handles) > 10 else 1,
@@ -1504,7 +1575,6 @@ class LapTimeChartWindow(PitWallWindow):
                 }
             for leg_text, orig_label in zip(leg.get_texts(), labels):
                 leg_text.set_picker(True)
-                leg_text.set_fontfamily("monospace")
                 self._legend_map[leg_text] = orig_label
                 self._legend_text_by_code[orig_label] = leg_text
                 self._legend_text_style_by_code[orig_label] = {
@@ -1584,6 +1654,7 @@ class LapTimeChartWindow(PitWallWindow):
         self._rebuild_hover_screen_cache()
         self._has_ever_drawn = True
         self._last_crosshair_state = None
+        self._last_rendered_terminal_signature = self._terminal_visibility_signature()
         if not self._restore_hover_point(previous_hover_point_key):
             self._refresh_hover_from_cursor()
         self._canvas.draw_idle()
@@ -1966,11 +2037,10 @@ class LapTimeChartWindow(PitWallWindow):
             extra_lines.append(info["status"])
 
         if info.get("is_terminal_no_time"):
-            text = (
-                f"{info['code']}  Lap {info['lap']}\n"
-                f"Lap time not available\n"
-                f"({info.get('status', 'Retired')})"
-            )
+            text = f"{info['code']}  Lap {info['lap']}"
+            if tyre_name:
+                text += f"\n({tyre_name}{tyre_life_str})"
+            text += f"\n{_terminal_status_display_text(info.get('status'))}"
         elif self._is_gap_mode():
             text = (
                 f"{info['code']}  Lap {info['lap']}{badge}\n"

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -18,7 +18,7 @@ data, so they are deterministic regardless of playback speed.
 """
 
 import sys
-from collections import defaultdict
+import time
 
 import numpy as np
 import matplotlib
@@ -29,8 +29,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 
 from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout,
-    QLabel, QComboBox, QPushButton, QCheckBox, QFrame, QDoubleSpinBox,
-    QDialog, QFormLayout, QDialogButtonBox
+    QLabel, QComboBox, QPushButton, QCheckBox
 )
 from PySide6.QtGui import QFont, QFontMetrics
 from PySide6.QtCore import Qt, QEvent
@@ -70,6 +69,79 @@ _TYRE_COLOURS = {
 
 # Moving average window
 _MA_WINDOW = 3
+_YMODE_TIME = "absolute"
+_YMODE_GAP = "gap"
+
+
+def _hex_to_rgb01(colour):
+    colour = str(colour or "").strip()
+    if not colour.startswith("#") or len(colour) != 7:
+        return None
+    try:
+        return tuple(int(colour[i:i + 2], 16) / 255.0 for i in (1, 3, 5))
+    except ValueError:
+        return None
+
+
+def _rgb01_to_hex(rgb):
+    return "#{:02X}{:02X}{:02X}".format(
+        int(max(0.0, min(1.0, rgb[0])) * 255.0),
+        int(max(0.0, min(1.0, rgb[1])) * 255.0),
+        int(max(0.0, min(1.0, rgb[2])) * 255.0),
+    )
+
+
+def _srgb_to_linear(channel):
+    if channel <= 0.04045:
+        return channel / 12.92
+    return ((channel + 0.055) / 1.055) ** 2.4
+
+
+def _relative_luminance(rgb):
+    r, g, b = (_srgb_to_linear(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(fg_hex, bg_hex):
+    fg_rgb = _hex_to_rgb01(fg_hex)
+    bg_rgb = _hex_to_rgb01(bg_hex)
+    if fg_rgb is None or bg_rgb is None:
+        return 1.0
+    fg_l = _relative_luminance(fg_rgb)
+    bg_l = _relative_luminance(bg_rgb)
+    lighter = max(fg_l, bg_l)
+    darker = min(fg_l, bg_l)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _mix_rgb(rgb_a, rgb_b, amount):
+    return tuple(
+        (1.0 - amount) * a + amount * b
+        for a, b in zip(rgb_a, rgb_b)
+    )
+
+
+def _display_safe_colour(colour, bg_colour=_BG, min_contrast=3.2):
+    if _contrast_ratio(colour, bg_colour) >= min_contrast:
+        return colour
+
+    rgb = _hex_to_rgb01(colour)
+    if rgb is None:
+        return colour
+
+    white = (1.0, 1.0, 1.0)
+    lo, hi = 0.0, 1.0
+    best = white
+    for _ in range(16):
+        mid = (lo + hi) / 2.0
+        candidate = _mix_rgb(rgb, white, mid)
+        candidate_hex = _rgb01_to_hex(candidate)
+        if _contrast_ratio(candidate_hex, bg_colour) >= min_contrast:
+            best = candidate
+            hi = mid
+        else:
+            lo = mid
+    return _rgb01_to_hex(best)
 
 
 def _format_laptime(seconds, _pos=None):
@@ -112,10 +184,17 @@ def _moving_average(values, window):
     return result
 
 
-def _entry_is_pit(entry, pit_threshold):
-    is_pit = entry.get("is_pit")
-    if is_pit is not None:
-        return bool(is_pit)
+def _entry_is_pit_entry(entry):
+    return bool(entry.get("is_pit_entry"))
+
+
+def _entry_is_pit_affected(entry, pit_threshold):
+    explicit = entry.get("is_pit_affected")
+    if explicit is not None:
+        return bool(explicit)
+    legacy = entry.get("is_pit")
+    if legacy is not None:
+        return bool(legacy)
     return entry.get("time_s", -1) > pit_threshold and entry.get("lap", 0) > 1
 
 
@@ -129,8 +208,20 @@ def _entry_is_outlier(entry, pit_threshold):
         return bool(explicit)
     return (
         entry.get("time_s", -1) > pit_threshold
-        and not _entry_is_pit(entry, pit_threshold)
+        and not _entry_is_pit_affected(entry, pit_threshold)
         and not _entry_is_out_lap(entry)
+    )
+
+
+def _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps):
+    if not entry:
+        return False
+    lap = entry.get("lap")
+    return (
+        _entry_is_pit_affected(entry, pit_threshold)
+        or _entry_is_out_lap(entry)
+        or _entry_is_outlier(entry, pit_threshold)
+        or (lap in sc_vsc_laps if lap is not None else False)
     )
 
 
@@ -149,9 +240,20 @@ class LapTimeChartWindow(PitWallWindow):
         self._last_drawn_lap = 0
         self._needs_full_redraw = True
         self._focused_drivers = set()   # set of codes
-        self._y_mode = "absolute"       # "absolute" | "gap"
+        self._y_mode = _YMODE_TIME
         self._has_ever_drawn = False    # True after first successful redraw
         self._legend_visible = True
+        self._legend_artist = None
+        self._legend_map = {}
+        self._legend_line_by_code = {}
+        self._legend_text_by_code = {}
+        self._legend_line_style_by_code = {}
+        self._legend_text_style_by_code = {}
+        self._plot_line_by_code = {}
+        self._plot_line_style_by_code = {}
+        self._hover_legend_code = None
+        self._shift_held = False
+        self._use_native_pinch_zoom = False
 
         # Crosshair annotation
         self._annot = None
@@ -174,14 +276,14 @@ class LapTimeChartWindow(PitWallWindow):
         self._view_state_by_mode = {}
         self._undo_stack = []
         self._redo_stack = []
+        self._last_zoom_ts = 0.0
+        self._last_pan_draw_ts = 0.0
         # Crosshair debounce
         self._last_crosshair_state = None
 
         super().__init__()
 
-        # Map graph line artists to driver codes
-        self._artist_to_driver = {}
-        self.setWindowTitle("F1 Race Replay - Lap Time Evolution")
+        self.setWindowTitle("F1 Race Replay - Lap Time & Gap Evolution")
         self.setGeometry(120, 120, 1000, 600)
         
         self.status_bar.setStyleSheet("""
@@ -264,7 +366,7 @@ class LapTimeChartWindow(PitWallWindow):
             return None
         return ref_s - ref["ref_s"]
 
-    def _display_gap_meta(self, entry, leader_refs=None, official_gap_laps=None, code=None):
+    def _display_gap_meta(self, entry, leader_refs=None, code=None):
         if not entry:
             return None, False
 
@@ -281,6 +383,9 @@ class LapTimeChartWindow(PitWallWindow):
         if finish_gap_s is not None:
             return (0.0 if -0.05 < finish_gap_s < 0 else finish_gap_s), False
 
+        if code is not None and (code, entry.get("lap")) in getattr(self, "_cached_gap_suppressed_laps", set()):
+            return None, False
+
         adjusted = None
         if code is not None:
             adjusted = getattr(self, "_cached_gap_adjustments", {}).get((code, entry.get("lap")))
@@ -292,8 +397,14 @@ class LapTimeChartWindow(PitWallWindow):
             return None, False
         return (0.0 if -0.05 < val < 0 else val), True
 
-    def _display_gap_value(self, entry, leader_refs=None, official_gap_laps=None, code=None):
-        val, _ = self._display_gap_meta(entry, leader_refs, official_gap_laps, code)
+    def _is_time_mode(self):
+        return self._y_mode == _YMODE_TIME
+
+    def _is_gap_mode(self):
+        return self._y_mode == _YMODE_GAP
+
+    def _display_gap_value(self, entry, leader_refs=None, code=None):
+        val, _ = self._display_gap_meta(entry, leader_refs, code)
         return val
 
     def setup_ui(self):
@@ -340,11 +451,6 @@ class LapTimeChartWindow(PitWallWindow):
 
         ctrl.addSpacing(18)
 
-        self._axis_limits_btn = QPushButton("Axis Limits")
-        self._axis_limits_btn.setFont(QFont("Arial", 10))
-        self._axis_limits_btn.clicked.connect(self._open_axis_limits_dialog)
-        ctrl.addWidget(self._axis_limits_btn)
-
         self._undo_btn = QPushButton("Undo")
         self._undo_btn.setFont(QFont("Arial", 10))
         self._undo_btn.clicked.connect(self._undo_view)
@@ -354,7 +460,12 @@ class LapTimeChartWindow(PitWallWindow):
         self._redo_btn.setFont(QFont("Arial", 10))
         self._redo_btn.clicked.connect(self._redo_view)
         ctrl.addWidget(self._redo_btn)
-        
+
+        self._reset_btn = QPushButton("Reset")
+        self._reset_btn.setFont(QFont("Arial", 10))
+        self._reset_btn.clicked.connect(self._reset_view)
+        ctrl.addWidget(self._reset_btn)
+
         ctrl.addStretch()
         
         self._help_btn = QPushButton("?")
@@ -401,23 +512,25 @@ class LapTimeChartWindow(PitWallWindow):
 
         self._canvas = FigureCanvas(self._fig)
         self._canvas.setStyleSheet("border: none; outline: none;")
+        self._canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self._canvas.setSizePolicy(
             self._canvas.sizePolicy().horizontalPolicy(),
             self._canvas.sizePolicy().verticalPolicy(),
         )
         root.addWidget(self._canvas, stretch=1)
 
-        # Connect mouse events: crosshair, legend/line pick, scroll-zoom, drag-pan
+        # Connect mouse events: crosshair, legend/line pick, drag-pan
         self._canvas.mpl_connect("motion_notify_event", self._on_mouse_move)
         self._canvas.mpl_connect("pick_event", self._on_pick)
-        self._canvas.mpl_connect("scroll_event", self._on_scroll)
         self._canvas.mpl_connect("button_press_event", self._on_button_press)
         self._canvas.mpl_connect("button_release_event", self._on_button_release)
 
-        # Enable pinch-to-zoom gesture on macOS trackpad
-        self._canvas.grabGesture(Qt.GestureType.PinchGesture)
+        app = QApplication.instance()
+        platform_name = (app.platformName().lower() if app is not None else "")
+        self._use_native_pinch_zoom = platform_name in {"cocoa", "wayland"}
+        if not self._use_native_pinch_zoom:
+            self._canvas.grabGesture(Qt.GestureType.PinchGesture)
         self._canvas.installEventFilter(self)
-        self._pinch_scale_accum = 1.0
 
         self._create_overlays()
 
@@ -439,7 +552,7 @@ class LapTimeChartWindow(PitWallWindow):
         """)
         self._help_overlay.setFont(QFont("Arial", 11))
         self._help_overlay.setText(
-            "<h3>🏎️ Lap Time Evolution</h3>"
+            "<h3>🏎️ Lap Time & Gap Evolution</h3>"
             "<h4>Key Features</h4>"
             "<ul>"
             "<li><b>Tyre Compounds:</b> Markers indicate compound (Soft=●, Medium=■, Hard=▲, Inter=◆, Wet=★)</li>"
@@ -450,12 +563,13 @@ class LapTimeChartWindow(PitWallWindow):
             "</ul>"
             "<h4>Controls</h4>"
             "<ul>"
-            "<li><b>Scroll / Pinch:</b> Zoom in & out</li>"
-            "<li><b>Axis Limits:</b> Enter exact X/Y ranges</li>"
-            "<li><b>Left-Click & Drag:</b> Pan around the chart</li>"
+            "<li><b>Scroll / Pinch:</b> Zoom the x-axis at the cursor</li>"
+            "<li><b>Shift + Scroll / Pinch:</b> Zoom the y-axis at the cursor</li>"
+            "<li><b>Left-Click & Drag:</b> Pan the chart</li>"
+            "<li><b>Arrow Keys:</b> Pan the view after clicking the chart</li>"
             "<li><b>Undo / Redo:</b> Step backward or forward through chart views</li>"
-            "<li><b>Double-Click:</b> Reset view to full race</li>"
-            "<li><b>Click Legend:</b> Toggle driver isolation for comparison</li>"
+            "<li><b>Double-Click:</b> Return to the default view</li>"
+            "<li><b>Click Legend:</b> Click a driver line or label to toggle isolation</li>"
             "<li><b>H:</b> Toggle this help overlay</li>"
             "<li><b>I:</b> Show or hide the legend</li>"
             "<li><b>Hover:</b> View exact lap times & tyre life</li>"
@@ -476,14 +590,16 @@ class LapTimeChartWindow(PitWallWindow):
 
     def _setup_axes(self, ax):
         """Apply consistent styling to the axes."""
+        ax.set_xscale("linear")
+        ax.set_yscale("linear")
         ax.set_facecolor(_BG)
         ax.set_xlabel("Lap", color=_TEXT, fontsize=10)
-        if self._y_mode == "gap":
+        if self._is_gap_mode():
             ax.set_ylabel("Gap to Leader (s)", color=_TEXT, fontsize=10)
         else:
             ax.set_ylabel("Lap Time", color=_TEXT, fontsize=10)
         ax.tick_params(colors=_TEXT, labelsize=9)
-        if self._y_mode == "absolute":
+        if self._is_time_mode():
             ax.yaxis.set_major_formatter(ticker.FuncFormatter(_format_laptime))
         else:
             ax.yaxis.set_major_formatter(ticker.FuncFormatter(_format_delta))
@@ -505,7 +621,10 @@ class LapTimeChartWindow(PitWallWindow):
         # Capture colours
         colors = data.get("driver_colors", {})
         if colors:
-            self._driver_colors = colors
+            self._driver_colors = {
+                code: _display_safe_colour(hex_colour)
+                for code, hex_colour in colors.items()
+            }
 
         # Capture session info
         sd = data.get("session_data", {})
@@ -583,7 +702,7 @@ class LapTimeChartWindow(PitWallWindow):
     def _on_ymode_changed(self, index):
         self._push_undo_state()
         self._save_view_state()
-        self._y_mode = "absolute" if index == 0 else "gap"
+        self._y_mode = _YMODE_TIME if index == 0 else _YMODE_GAP
         self._restore_view_state()
         self._needs_full_redraw = True
         self._redraw()
@@ -634,7 +753,7 @@ class LapTimeChartWindow(PitWallWindow):
         if mode != self._y_mode:
             self._y_mode = mode
             self._ymode_combo.blockSignals(True)
-            self._ymode_combo.setCurrentIndex(0 if mode == "absolute" else 1)
+            self._ymode_combo.setCurrentIndex(0 if mode == _YMODE_TIME else 1)
             self._ymode_combo.blockSignals(False)
             self._user_xlim = tuple(snapshot["xlim"])
             self._user_ylim = tuple(snapshot["ylim"])
@@ -674,55 +793,6 @@ class LapTimeChartWindow(PitWallWindow):
         if hasattr(self, "_redo_btn"):
             self._redo_btn.setEnabled(bool(self._redo_stack))
 
-    def _open_axis_limits_dialog(self):
-        if not hasattr(self, "_ax"):
-            return
-        x_lo, x_hi = self._ax.get_xlim()
-        y_lo, y_hi = self._ax.get_ylim()
-        allowed_x_lo, allowed_x_hi = self._home_xlim if self._home_xlim else (x_lo, x_hi)
-        allowed_y_lo, allowed_y_hi = self._max_ylim if hasattr(self, "_max_ylim") else (y_lo, y_hi)
-
-        dialog = QDialog(self)
-        dialog.setWindowTitle("Axis Limits")
-        form = QFormLayout(dialog)
-        spinboxes = []
-        for label, value, min_value, max_value, step in (
-            ("X min", x_lo, allowed_x_lo, allowed_x_hi, 1.0),
-            ("X max", x_hi, allowed_x_lo, allowed_x_hi, 1.0),
-            ("Y min", y_lo, allowed_y_lo, allowed_y_hi, 1.0),
-            ("Y max", y_hi, allowed_y_lo, allowed_y_hi, 1.0),
-        ):
-            spin = QDoubleSpinBox(dialog)
-            spin.setRange(float(min_value), float(max_value))
-            spin.setDecimals(3)
-            spin.setSingleStep(step)
-            spin.setValue(float(min(max(value, min_value), max_value)))
-            form.addRow(label, spin)
-            spinboxes.append(spin)
-
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
-            parent=dialog,
-        )
-        buttons.accepted.connect(dialog.accept)
-        buttons.rejected.connect(dialog.reject)
-        form.addRow(buttons)
-
-        if dialog.exec() != QDialog.DialogCode.Accepted:
-            return
-        new_x_lo, new_x_hi, new_y_lo, new_y_hi = [spin.value() for spin in spinboxes]
-        new_x_lo = max(allowed_x_lo, min(new_x_lo, allowed_x_hi))
-        new_x_hi = max(allowed_x_lo, min(new_x_hi, allowed_x_hi))
-        new_y_lo = max(allowed_y_lo, min(new_y_lo, allowed_y_hi))
-        new_y_hi = max(allowed_y_lo, min(new_y_hi, allowed_y_hi))
-        if new_x_hi <= new_x_lo or new_y_hi <= new_y_lo:
-            return
-        self._push_undo_state()
-        self._ax.set_xlim(new_x_lo, new_x_hi)
-        self._ax.set_ylim(new_y_lo, new_y_hi)
-        self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
-        self._canvas.draw_idle()
-
     def _on_pure_pace_toggled(self, state):
         self._needs_full_redraw = True
         self._redraw()
@@ -743,6 +813,14 @@ class LapTimeChartWindow(PitWallWindow):
         self._setup_axes(ax)
         self._annot = None
         self._legend_artist = None
+        self._legend_map = {}
+        self._legend_line_by_code = {}
+        self._legend_text_by_code = {}
+        self._legend_line_style_by_code = {}
+        self._legend_text_style_by_code = {}
+        self._plot_line_by_code = {}
+        self._plot_line_style_by_code = {}
+        self._hover_legend_code = None
 
         if not self._lap_times:
             self._canvas.draw_idle()
@@ -819,7 +897,7 @@ class LapTimeChartWindow(PitWallWindow):
             for code, entries in visible_data.items()
         }
         leader_refs = {}
-        if self._y_mode == "gap":
+        if self._is_gap_mode():
             for lap in sorted({e["lap"] for entries in visible_data.values() for e in entries}):
                 official_candidates = []
                 candidates = []
@@ -849,7 +927,8 @@ class LapTimeChartWindow(PitWallWindow):
                     }
         gap_adjustments = {}
         gap_overrides = {}
-        if self._y_mode == "gap":
+        gap_suppressed_laps = set()
+        if self._is_gap_mode():
             for code, entries in visible_data.items():
                 sorted_entries = sorted(entries, key=lambda item: item["lap"])
                 anchors = []
@@ -861,6 +940,7 @@ class LapTimeChartWindow(PitWallWindow):
                     if official_val is not None and raw_val is not None:
                         anchors.append({
                             "lap": entry["lap"],
+                            "official_gap": float(official_val),
                             "offset": float(official_val) - float(raw_val),
                         })
 
@@ -868,12 +948,16 @@ class LapTimeChartWindow(PitWallWindow):
                     continue
 
                 for entry in sorted_entries:
-                    if self._official_gap_to_leader_s(entry) is not None or self._official_finish_gap_s(entry) is not None:
+                    lap = entry["lap"]
+                    has_official = (
+                        self._official_gap_to_leader_s(entry) is not None
+                        or self._official_finish_gap_s(entry) is not None
+                    )
+                    if has_official:
                         continue
                     raw_val = self._raw_gap_fallback_s(entry, leader_refs)
                     if raw_val is None:
                         continue
-                    lap = entry["lap"]
                     prev_anchor = None
                     next_anchor = None
                     for anchor in anchors:
@@ -895,13 +979,43 @@ class LapTimeChartWindow(PitWallWindow):
                         offset = next_anchor["offset"]
                     else:
                         continue
-                    gap_adjustments[(code, lap)] = raw_val + offset
+                    adjusted_val = raw_val + offset
+                    bridged_val = None
+                    if prev_anchor and next_anchor:
+                        span = next_anchor["lap"] - prev_anchor["lap"]
+                        if span > 0:
+                            t = (lap - prev_anchor["lap"]) / span
+                            bridged_val = (
+                                prev_anchor["official_gap"]
+                                + t * (next_anchor["official_gap"] - prev_anchor["official_gap"])
+                            )
+                    if (
+                        bridged_val is not None
+                        and _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps)
+                        and (
+                            not np.isfinite(adjusted_val)
+                            or adjusted_val < -0.05
+                            or abs(adjusted_val - bridged_val) > 45.0
+                        )
+                    ):
+                        adjusted_val = bridged_val
+                    if not np.isfinite(adjusted_val) or adjusted_val < -0.05:
+                        gap_suppressed_laps.add((code, lap))
+                        continue
+                    gap_adjustments[(code, lap)] = adjusted_val
             gap_override_threshold = 5.0
             for code, entries in visible_data.items():
                 sorted_entries = sorted(entries, key=lambda item: item["lap"])
                 prev_gap = None
+                prev_gap_lap = None
+                prev_gap_trustworthy = False
                 for entry in sorted_entries:
                     lap = entry["lap"]
+                    if (code, lap) in gap_suppressed_laps:
+                        prev_gap = None
+                        prev_gap_lap = None
+                        prev_gap_trustworthy = False
+                        continue
                     leader_ref = leader_refs.get(lap)
                     leader_time_s = None if leader_ref is None else leader_ref.get("time_s")
                     official_val = self._official_gap_to_leader_s(entry)
@@ -915,15 +1029,19 @@ class LapTimeChartWindow(PitWallWindow):
                     if (
                         official_val is not None
                         and prev_gap is not None
+                        and prev_gap_lap == lap - 1
+                        and prev_gap_trustworthy
                         and entry.get("time_s", -1) > 0
                         and leader_time_s is not None
                         and leader_time_s > 0
                     ):
                         predicted = prev_gap + float(entry["time_s"]) - float(leader_time_s)
                         if (
+                            predicted >= -0.05
+                            and
                             abs(float(official_val) - predicted) > gap_override_threshold
                             and (
-                                _entry_is_pit(entry, pit_threshold)
+                                _entry_is_pit_affected(entry, pit_threshold)
                                 or _entry_is_out_lap(entry)
                                 or _entry_is_outlier(entry, pit_threshold)
                             )
@@ -933,18 +1051,20 @@ class LapTimeChartWindow(PitWallWindow):
 
                     if display_val is not None:
                         prev_gap = float(display_val)
-        official_gap_laps = {
-            lap for lap, ref in leader_refs.items() if ref.get("uses_official_gap")
-        }
-
+                        prev_gap_lap = lap
+                        prev_gap_trustworthy = official_val is not None
+                    else:
+                        prev_gap = None
+                        prev_gap_lap = None
+                        prev_gap_trustworthy = False
         # Cache variables for O(1) lookups during high-frequency mouse hover events
-        self._cached_visible_data = visible_data
         self._cached_pit_threshold = pit_threshold
         self._cached_leader_refs = leader_refs
-        self._cached_official_gap_laps = official_gap_laps
         self._cached_gap_adjustments = gap_adjustments
         self._cached_gap_overrides = gap_overrides
+        self._cached_gap_suppressed_laps = gap_suppressed_laps
         self._cached_terminal_no_time_points = []
+        self._cached_hover_candidates = []
                         
         for sp in self._status_laps:
             if sp["start_lap"] > self._leader_lap:
@@ -992,7 +1112,6 @@ class LapTimeChartWindow(PitWallWindow):
         y_max = float("-inf")
 
         # Store line references for picking
-        self._artist_to_driver = {}
         driver_stints_text = {}
         display_y_vals = []
         all_axis_y_vals = []
@@ -1004,7 +1123,7 @@ class LapTimeChartWindow(PitWallWindow):
                 if (
                     0 < e["time_s"] <= pit_threshold
                     and e["lap"] not in sc_vsc_laps
-                    and not _entry_is_pit(e, pit_threshold)
+                    and not _entry_is_pit_affected(e, pit_threshold)
                     and not _entry_is_out_lap(e)
                     and not _entry_is_outlier(e, pit_threshold)
                 ):
@@ -1032,7 +1151,7 @@ class LapTimeChartWindow(PitWallWindow):
 
             clean_laps, clean_vals, clean_time_s, clean_tyres = [], [], [], []
             pit_laps, pit_vals = [], []
-            all_laps, all_vals, all_markers = [], [], []
+            all_laps, all_vals, all_markers, all_marker_colours = [], [], [], []
             terminal_no_time_laps = []
             
             drv_clean_times = [
@@ -1040,7 +1159,7 @@ class LapTimeChartWindow(PitWallWindow):
                 if (
                     0 < e["time_s"] <= pit_threshold
                     and e["lap"] not in sc_vsc_laps
-                    and not _entry_is_pit(e, pit_threshold)
+                    and not _entry_is_pit_affected(e, pit_threshold)
                     and not _entry_is_out_lap(e)
                     and not _entry_is_outlier(e, pit_threshold)
                 )
@@ -1051,17 +1170,20 @@ class LapTimeChartWindow(PitWallWindow):
             for e in entries:
                 lap = e["lap"]
                 raw_time = e["time_s"]
-                is_pit = _entry_is_pit(e, pit_threshold)
+                is_pit_affected = _entry_is_pit_affected(e, pit_threshold)
+                is_pit_entry = _entry_is_pit_entry(e)
                 is_out_lap = _entry_is_out_lap(e)
                 is_outlier = _entry_is_outlier(e, pit_threshold)
 
-                if pure_pace and (lap in sc_vsc_laps or is_pit or is_out_lap or is_outlier):
+                if pure_pace and (lap in sc_vsc_laps or is_pit_affected or is_out_lap or is_outlier):
                     continue
 
-                if self._y_mode == "gap":
-                    val = self._display_gap_value(e, leader_refs, official_gap_laps, code)
+                gap_is_approx = False
+                if self._is_gap_mode():
+                    gap_val, gap_is_approx = self._display_gap_meta(e, leader_refs, code)
+                    val = gap_val
                     if val is None:
-                        if is_pit:
+                        if is_pit_entry:
                             pit_laps.append(lap)
                             pit_vals.append(0)
                         continue
@@ -1069,7 +1191,7 @@ class LapTimeChartWindow(PitWallWindow):
                     if raw_time < 0:
                         if e.get("is_terminal_lap"):
                             terminal_no_time_laps.append(lap)
-                        if is_pit:
+                        if is_pit_entry:
                             pit_laps.append(lap)
                             pit_vals.append(0) # Dummy value, won't be plotted on main line
                         continue
@@ -1078,8 +1200,9 @@ class LapTimeChartWindow(PitWallWindow):
                 all_laps.append(lap)
                 all_vals.append(val)
                 all_markers.append(_TYRE_MARKERS.get(e.get("tyre", -1), _DEFAULT_MARKER))
+                all_marker_colours.append(_TYRE_COLOURS.get(e.get("tyre", -1), colour))
 
-                if is_pit:
+                if is_pit_entry:
                     # Explicit pit stop (In-Lap)
                     pit_laps.append(lap)
                     pit_vals.append(val)
@@ -1093,6 +1216,19 @@ class LapTimeChartWindow(PitWallWindow):
                     clean_time_s.append(raw_time)
                     clean_tyres.append(e.get("tyre", -1))
 
+                if show_detail or e["time_s"] == session_best:
+                    self._cached_hover_candidates.append({
+                        "code": code,
+                        "lap": lap,
+                        "time_s": e["time_s"],
+                        "val": val,
+                        "tyre": e.get("tyre", -1),
+                        "tyre_life": e.get("tyre_life", 0),
+                        "is_approx": self._is_approx_time_entry(e) if self._is_time_mode() else gap_is_approx,
+                        "is_terminal_lap": bool(e.get("is_terminal_lap")),
+                        "status": e.get("result_status"),
+                    })
+
             # Main pace line
             if all_laps:
                 line, = ax.plot(
@@ -1101,8 +1237,12 @@ class LapTimeChartWindow(PitWallWindow):
                     zorder=zorder,
                     label=code,
                 )
-                self._artist_to_driver[line] = code
-
+                self._plot_line_by_code[code] = line
+                self._plot_line_style_by_code[code] = {
+                    "alpha": 1.0 if line.get_alpha() is None else float(line.get_alpha()),
+                    "linewidth": float(line.get_linewidth()),
+                    "zorder": float(line.get_zorder()),
+                }
                 purple_laps, purple_vals = [], []
                 green_laps, green_vals = [], []
                 for lp, tv, ts in zip(clean_laps, clean_vals, clean_time_s):
@@ -1120,30 +1260,34 @@ class LapTimeChartWindow(PitWallWindow):
 
                 # ── 3. Tyre compound markers ──
                 prev_mk = None
+                prev_marker_colour = None
                 gx, gy = [], []
-                for lp, tv, mk in zip(all_laps, all_vals, all_markers):
-                    if mk != prev_mk and gx:
+                for lp, tv, mk, mk_colour in zip(all_laps, all_vals, all_markers, all_marker_colours):
+                    if (mk != prev_mk or mk_colour != prev_marker_colour) and gx:
                         ax.scatter(
                             gx, gy, marker=prev_mk,
-                            color=colour, alpha=alpha * 0.9,
+                            facecolors=prev_marker_colour,
+                            alpha=alpha * 0.95,
                             s=22 if show_detail else 6,
-                            zorder=zorder + 1, edgecolors="none",
+                            zorder=zorder + 1, edgecolors=colour, linewidths=0.4 if show_detail else 0.25,
                         )
                         gx, gy = [], []
                     gx.append(lp)
                     gy.append(tv)
                     prev_mk = mk
+                    prev_marker_colour = mk_colour
                 if gx:
                     ax.scatter(
                         gx, gy, marker=prev_mk,
-                        color=colour, alpha=alpha * 0.9,
+                        facecolors=prev_marker_colour,
+                        alpha=alpha * 0.95,
                         s=22 if show_detail else 6,
-                        zorder=zorder + 1, edgecolors="none",
+                        zorder=zorder + 1, edgecolors=colour, linewidths=0.4 if show_detail else 0.25,
                     )
 
                 # ── 5. Tyre stint background bands (focused driver only) ──
                 if show_detail and focus:
-                    drv_pit_lap_set = {e["lap"] for e in entries if _entry_is_pit(e, pit_threshold)}
+                    drv_pit_lap_set = {e["lap"] for e in entries if _entry_is_pit_entry(e)}
                     stint_str = self._draw_stint_bands(ax, clean_laps, clean_vals, clean_tyres, zorder - 1, drv_pit_lap_set)
                     if stint_str:
                         driver_stints_text[code] = stint_str
@@ -1185,7 +1329,7 @@ class LapTimeChartWindow(PitWallWindow):
                         transform=ax.get_xaxis_transform()
                     )
 
-            if terminal_no_time_laps and focus and is_focused and self._y_mode == "time":
+            if terminal_no_time_laps and focus and is_focused and self._is_time_mode():
                 for pl in terminal_no_time_laps:
                     status_text = next(
                         (
@@ -1216,13 +1360,13 @@ class LapTimeChartWindow(PitWallWindow):
                     if (
                         e["time_s"] <= pit_threshold
                         and e["lap"] not in sc_vsc_laps
-                        and not _entry_is_pit(e, pit_threshold)
+                        and not _entry_is_pit_affected(e, pit_threshold)
                         and not _entry_is_out_lap(e)
                         and not _entry_is_outlier(e, pit_threshold)
                     )
                 ]
                 # Count actual pit stops (group consecutive in/out laps)
-                pit_laps = [e["lap"] for e in visible_data[code] if _entry_is_pit(e, pit_threshold)]
+                pit_laps = [e["lap"] for e in visible_data[code] if _entry_is_pit_entry(e)]
                 drv_pit_stops = len(pit_laps)
                 
                 if drv_clean_times:
@@ -1241,7 +1385,7 @@ class LapTimeChartWindow(PitWallWindow):
         # Y-axis padding. Gap mode defaults to a useful battle view instead
         # of letting retired or long-stopped cars flatten the competitive field.
         if display_y_vals:
-            if self._y_mode == "gap":
+            if self._is_gap_mode():
                 # Keep a stable default race-gap view even when a driver is
                 # focused. Long garage stops / repairs should not re-scale the
                 # whole chart around one outlier trace.
@@ -1254,7 +1398,7 @@ class LapTimeChartWindow(PitWallWindow):
                 pad = max(2.0, (y_max_display - y_min_display) * 0.06)
                 ax.set_ylim(y_min_display - pad, y_max_display + pad)
 
-        if self._cached_terminal_no_time_points and self._y_mode == "time":
+        if self._cached_terminal_no_time_points and self._is_time_mode():
             y_lo, y_hi = ax.get_ylim()
             span = max(y_hi - y_lo, 1.0)
             marker_y = y_hi - span * 0.045
@@ -1266,6 +1410,17 @@ class LapTimeChartWindow(PitWallWindow):
                     alpha=point["alpha"], s=46, linewidths=1.4,
                     zorder=point["zorder"],
                 )
+                self._cached_hover_candidates.append({
+                    "code": point["code"],
+                    "lap": point["lap"],
+                    "time_s": -1.0,
+                    "val": marker_y,
+                    "tyre": -1,
+                    "tyre_life": 0,
+                    "is_approx": False,
+                    "is_terminal_no_time": True,
+                    "status": point.get("status", "Retired"),
+                })
 
         # X-axis
         all_laps = [e["lap"] for v in visible_data.values() for e in v]
@@ -1289,6 +1444,20 @@ class LapTimeChartWindow(PitWallWindow):
                 leg_line.set_picker(5)
                 leg_line.set_pickradius(5)
                 self._legend_map[leg_line] = orig_label
+                self._legend_line_by_code[orig_label] = leg_line
+                self._legend_line_style_by_code[orig_label] = {
+                    "alpha": 1.0 if leg_line.get_alpha() is None else float(leg_line.get_alpha()),
+                    "linewidth": float(leg_line.get_linewidth()),
+                }
+            for leg_text, orig_label in zip(leg.get_texts(), labels):
+                leg_text.set_picker(True)
+                self._legend_map[leg_text] = orig_label
+                self._legend_text_by_code[orig_label] = leg_text
+                self._legend_text_style_by_code[orig_label] = {
+                    "color": leg_text.get_color(),
+                    "fontweight": leg_text.get_fontweight(),
+                    "alpha": 1.0 if leg_text.get_alpha() is None else float(leg_text.get_alpha()),
+                }
             ax.add_artist(leg)
 
         # ── 7. HUD Statistics Legend ──
@@ -1325,8 +1494,8 @@ class LapTimeChartWindow(PitWallWindow):
         all_v = []
         for vlist in visible_data.values():
             for e in vlist:
-                if self._y_mode == "gap":
-                    val = self._display_gap_value(e, leader_refs, official_gap_laps)
+                if self._is_gap_mode():
+                    val = self._display_gap_value(e, leader_refs)
                     if val is not None:
                         all_v.append(val)
                 else:
@@ -1337,7 +1506,7 @@ class LapTimeChartWindow(PitWallWindow):
         if all_v:
             y_min_abs, y_max_abs = min(all_v), max(all_v)
             pad_abs = (y_max_abs - y_min_abs) * 0.05
-            if self._y_mode == "gap":
+            if self._is_gap_mode():
                 self._max_ylim = (-5.0, y_max_abs + max(2.0, pad_abs))
             else:
                 # Keep the normal analytical lower bound from the default
@@ -1399,7 +1568,7 @@ class LapTimeChartWindow(PitWallWindow):
                     tyre_name = get_tyre_compound_str(stint_tyre)
                     if tyre_name:
                         tyre_char = tyre_name[0].upper()
-                        if self._y_mode == "gap":
+                        if self._is_gap_mode():
                             stints.append(f"{tyre_char}({_format_delta(avg_val)})")
                         else:
                             stints.append(f"{tyre_char}({_format_laptime(avg_val)})")
@@ -1419,8 +1588,63 @@ class LapTimeChartWindow(PitWallWindow):
         moved = inv.transform((dx_px, dy_px))
         return moved[0] - origin[0], moved[1] - origin[1]
 
+    def _clamp_view_limits(self, new_x_lo, new_x_hi, new_y_lo, new_y_hi):
+        if self._home_xlim:
+            hx_lo, hx_hi = self._home_xlim
+            if new_x_lo < hx_lo:
+                shift = hx_lo - new_x_lo
+                new_x_lo, new_x_hi = new_x_lo + shift, new_x_hi + shift
+            if new_x_hi > hx_hi:
+                shift = new_x_hi - hx_hi
+                new_x_lo, new_x_hi = new_x_lo - shift, new_x_hi - shift
+        if hasattr(self, "_max_ylim"):
+            hy_lo, hy_hi = self._max_ylim
+            if new_y_lo < hy_lo:
+                shift = hy_lo - new_y_lo
+                new_y_lo, new_y_hi = new_y_lo + shift, new_y_hi + shift
+            if new_y_hi > hy_hi:
+                shift = new_y_hi - hy_hi
+                new_y_lo, new_y_hi = new_y_lo - shift, new_y_hi - shift
+        return new_x_lo, new_x_hi, new_y_lo, new_y_hi
+
+    def _pan_view_by_fraction(self, frac_x=0.0, frac_y=0.0):
+        if not hasattr(self, "_ax"):
+            return
+        x_lo, x_hi = self._ax.get_xlim()
+        y_lo, y_hi = self._ax.get_ylim()
+        x_span = x_hi - x_lo
+        y_span = y_hi - y_lo
+        new_x_lo = x_lo + x_span * frac_x
+        new_x_hi = x_hi + x_span * frac_x
+        new_y_lo = y_lo + y_span * frac_y
+        new_y_hi = y_hi + y_span * frac_y
+        new_x_lo, new_x_hi, new_y_lo, new_y_hi = self._clamp_view_limits(
+            new_x_lo, new_x_hi, new_y_lo, new_y_hi
+        )
+        self._ax.set_xlim(new_x_lo, new_x_hi)
+        self._ax.set_ylim(new_y_lo, new_y_hi)
+        self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
+        self._canvas.draw_idle()
+
+    def _reset_view(self):
+        self._pan_press_px = None
+        self._pan_active = False
+        self._last_pan_draw_ts = 0.0
+        self._user_xlim = None
+        self._user_ylim = None
+        self._view_state_by_mode.pop(self._y_mode, None)
+        self._canvas.unsetCursor()
+        self._redraw()
+
     def _on_mouse_move(self, event):
         """Crosshair + tooltip on hover, and pixel-based drag-to-pan."""
+        legend_code = self._hovered_legend_code(event)
+        if legend_code is not None:
+            self._set_legend_hover_code(legend_code)
+            self._hide_hover()
+            return
+        self._set_legend_hover_code(None)
+
         # Guard: ignore events with no valid data coordinates
         if event.xdata is None or event.ydata is None:
             if self._annot and self._annot.get_visible():
@@ -1443,10 +1667,23 @@ class LapTimeChartWindow(PitWallWindow):
             dy_px = event.y - self._pan_press_px[1]
             if not self._pan_active:
                 if abs(dx_px) > 5 or abs(dy_px) > 5:
+                    self._push_undo_state()
                     self._pan_active = True
+                    self._canvas.setCursor(Qt.CursorShape.ClosedHandCursor)
+                    if self._annot and self._annot.get_visible():
+                        self._annot.set_visible(False)
+                    if self._crosshair_v:
+                        self._crosshair_v.set_visible(False)
+                    if self._crosshair_h:
+                        self._crosshair_h.set_visible(False)
+                    self._last_crosshair_state = None
+                    self._last_pan_draw_ts = 0.0
                 else:
                     return
             if self._pan_active:
+                now = time.monotonic()
+                if now - self._last_pan_draw_ts < (1.0 / 90.0):
+                    return
                 # Convert pixel delta to data delta
                 ddx, ddy = self._px_to_data_delta(dx_px, dy_px)
                 ox_lo, ox_hi = self._pan_origin_xlim
@@ -1454,27 +1691,13 @@ class LapTimeChartWindow(PitWallWindow):
                 # Subtract because dragging right should move view left
                 new_x_lo, new_x_hi = ox_lo - ddx, ox_hi - ddx
                 new_y_lo, new_y_hi = oy_lo - ddy, oy_hi - ddy
-                # Clamp to home boundaries
-                if self._home_xlim:
-                    hx_lo, hx_hi = self._home_xlim
-                    if new_x_lo < hx_lo:
-                        shift = hx_lo - new_x_lo
-                        new_x_lo, new_x_hi = new_x_lo + shift, new_x_hi + shift
-                    if new_x_hi > hx_hi:
-                        shift = new_x_hi - hx_hi
-                        new_x_lo, new_x_hi = new_x_lo - shift, new_x_hi - shift
-                if hasattr(self, '_max_ylim'):
-                    hy_lo, hy_hi = self._max_ylim
-                    if new_y_lo < hy_lo:
-                        shift = hy_lo - new_y_lo
-                        new_y_lo, new_y_hi = new_y_lo + shift, new_y_hi + shift
-                    if new_y_hi > hy_hi:
-                        shift = new_y_hi - hy_hi
-                        new_y_lo, new_y_hi = new_y_lo - shift, new_y_hi - shift
+                new_x_lo, new_x_hi, new_y_lo, new_y_hi = self._clamp_view_limits(
+                    new_x_lo, new_x_hi, new_y_lo, new_y_hi
+                )
                 self._ax.set_xlim(new_x_lo, new_x_hi)
                 self._ax.set_ylim(new_y_lo, new_y_hi)
                 self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
-                self._pan_active = True
+                self._last_pan_draw_ts = now
                 self._canvas.draw_idle()
                 return
 
@@ -1493,79 +1716,19 @@ class LapTimeChartWindow(PitWallWindow):
         best_dist_px2 = float("inf")
         best_info = None
 
-        focus = self._focused_drivers
-        visible_data = getattr(self, '_cached_visible_data', None)
-        if not visible_data:
+        hover_candidates = getattr(self, "_cached_hover_candidates", None)
+        if not hover_candidates:
             return
 
-        pit_threshold = getattr(self, '_cached_pit_threshold', float('inf'))
         leader_refs = getattr(self, '_cached_leader_refs', {})
-        official_gap_laps = getattr(self, '_cached_official_gap_laps', set())
-        terminal_no_time_points = getattr(self, '_cached_terminal_no_time_points', [])
-
-        for code, entries in visible_data.items():
-            is_focused_drv = (not focus) or (code in focus)
-            session_best_val = getattr(self, '_cached_session_best', float('inf'))
-            
-            if not is_focused_drv:
-                # For non-focused drivers, only check their session-best lap
-                entries = [e for e in entries if e["time_s"] == session_best_val]
-                if not entries:
-                    continue
-            for e in entries:
-                if self._pure_pace_cb.isChecked() and (
-                    _entry_is_pit(e, pit_threshold)
-                    or _entry_is_out_lap(e)
-                    or _entry_is_outlier(e, pit_threshold)
-                    or e["lap"] in getattr(self, '_cached_sc_vsc_laps', set())
-                ):
-                    continue
-                lap = e["lap"]
-                if self._y_mode == "gap":
-                    val, gap_is_approx = self._display_gap_meta(e, leader_refs, official_gap_laps, code)
-                    if val is None:
-                        continue
-                else:
-                    if e["time_s"] < 0:
-                        continue
-                    val = e["time_s"]
-                    gap_is_approx = False
-
-                px, py = self._ax.transData.transform((lap, val))
-                dx_px = px - event.x
-                dy_px = py - event.y
-                dist_px2 = dx_px * dx_px + dy_px * dy_px
-                if dist_px2 < best_dist_px2:
-                    best_dist_px2 = dist_px2
-                    best_info = {
-                        "code": code, "lap": lap,
-                        "time_s": e["time_s"], "val": val,
-                        "tyre": e.get("tyre", -1),
-                        "tyre_life": e.get("tyre_life", 0),
-                        "is_approx": self._is_approx_time_entry(e) if self._y_mode == "time" else gap_is_approx,
-                        "is_terminal_lap": bool(e.get("is_terminal_lap")),
-                        "status": e.get("result_status"),
-                    }
-
-        if self._y_mode == "time":
-            for point in terminal_no_time_points:
-                px, py = self._ax.transData.transform((point["lap"], point["val"]))
-                dx_px = px - event.x
-                dy_px = py - event.y
-                dist_px2 = dx_px * dx_px + dy_px * dy_px
-                if dist_px2 < best_dist_px2:
-                    best_dist_px2 = dist_px2
-                    best_info = {
-                        "code": point["code"],
-                        "lap": point["lap"],
-                        "time_s": -1.0,
-                        "val": point["val"],
-                        "tyre": -1,
-                        "tyre_life": 0,
-                        "is_approx": False,
-                        "is_terminal_no_time": True,
-                        "status": point.get("status", "Retired"),
-                    }
+        for info in hover_candidates:
+            px, py = self._ax.transData.transform((info["lap"], info["val"]))
+            dx_px = px - event.x
+            dy_px = py - event.y
+            dist_px2 = dx_px * dx_px + dy_px * dy_px
+            if dist_px2 < best_dist_px2:
+                best_dist_px2 = dist_px2
+                best_info = info
 
         hover_radius_px = 16
         if best_info and best_dist_px2 <= (hover_radius_px * hover_radius_px):
@@ -1574,7 +1737,7 @@ class LapTimeChartWindow(PitWallWindow):
             tyre_name = get_tyre_compound_str(info["tyre"])
 
             leader_ref = leader_refs.get(info["lap"])
-            if self._y_mode == "gap":
+            if self._is_gap_mode():
                 val_str = _format_delta(info['val'])
             else:
                 val_str = _format_laptime(info["time_s"])
@@ -1600,7 +1763,7 @@ class LapTimeChartWindow(PitWallWindow):
 
             extra_lines = []
             if (
-                self._y_mode == "absolute"
+                self._is_time_mode()
                 and is_personal_best
                 and personal_best < float('inf')
                 and session_best < float('inf')
@@ -1608,7 +1771,7 @@ class LapTimeChartWindow(PitWallWindow):
                 pb_gap = personal_best - session_best
                 extra_lines.append(f"Gap to SB: {_format_delta(pb_gap)}")
 
-            if self._y_mode == "gap" and leader_ref is not None:
+            if self._is_gap_mode() and leader_ref is not None:
                 extra_lines.append(
                     f"Race leader: {leader_ref['code']}"
                 )
@@ -1621,7 +1784,7 @@ class LapTimeChartWindow(PitWallWindow):
                     f"Lap time not available\n"
                     f"({info.get('status', 'Retired')})"
                 )
-            elif self._y_mode == "gap":
+            elif self._is_gap_mode():
                 text = (
                     f"{info['code']}  Lap {info['lap']}{badge}\n"
                     f"Gap: {val_str}\n"
@@ -1696,6 +1859,70 @@ class LapTimeChartWindow(PitWallWindow):
             return False
         return bbox.contains(event.x, event.y)
 
+    def _hovered_legend_code(self, event):
+        if not getattr(self, "_legend_map", None):
+            return None
+        if event is None:
+            return None
+        for artist, code in self._legend_map.items():
+            try:
+                contains, _ = artist.contains(event)
+            except Exception:
+                contains = False
+            if contains:
+                return code
+            try:
+                bbox = artist.get_window_extent(self._canvas.renderer)
+            except Exception:
+                continue
+            if bbox is not None and bbox.expanded(1.08, 1.25).contains(event.x, event.y):
+                return code
+        return None
+
+    def _set_legend_hover_code(self, code):
+        if code == self._hover_legend_code:
+            return
+        if self._hover_legend_code is not None:
+            self._apply_legend_hover_style(self._hover_legend_code, active=False)
+        self._hover_legend_code = code
+        if code is not None:
+            self._apply_legend_hover_style(code, active=True)
+        self._canvas.draw_idle()
+
+    def _apply_legend_hover_style(self, code, active):
+        plot_line = self._plot_line_by_code.get(code)
+        plot_style = self._plot_line_style_by_code.get(code, {})
+        if plot_line is not None and plot_style:
+            if active:
+                plot_line.set_alpha(min(1.0, plot_style["alpha"] + 0.20))
+                plot_line.set_linewidth(plot_style["linewidth"] + 1.0)
+                plot_line.set_zorder(plot_style["zorder"] + 5.0)
+            else:
+                plot_line.set_alpha(plot_style["alpha"])
+                plot_line.set_linewidth(plot_style["linewidth"])
+                plot_line.set_zorder(plot_style["zorder"])
+
+        legend_line = self._legend_line_by_code.get(code)
+        legend_line_style = self._legend_line_style_by_code.get(code, {})
+        if legend_line is not None and legend_line_style:
+            if active:
+                legend_line.set_alpha(1.0)
+                legend_line.set_linewidth(legend_line_style["linewidth"] + 1.0)
+            else:
+                legend_line.set_alpha(legend_line_style["alpha"])
+                legend_line.set_linewidth(legend_line_style["linewidth"])
+
+        legend_text = self._legend_text_by_code.get(code)
+        legend_text_style = self._legend_text_style_by_code.get(code, {})
+        if legend_text is not None and legend_text_style:
+            if active:
+                legend_text.set_color("#FFFFFF")
+                legend_text.set_alpha(1.0)
+            else:
+                legend_text.set_color(legend_text_style["color"])
+                legend_text.set_alpha(legend_text_style["alpha"])
+                legend_text.set_fontweight(legend_text_style["fontweight"])
+
     def _hide_hover(self):
         if self._annot:
             self._annot.set_visible(False)
@@ -1706,13 +1933,86 @@ class LapTimeChartWindow(PitWallWindow):
         self._last_crosshair_state = None
         self._canvas.draw_idle()
 
-    def _on_scroll(self, event):
-        """Scroll to zoom, centered on cursor position."""
-        if not event.inaxes:
+    def _update_modifier_latch(self, event, pressed):
+        if event.key() == Qt.Key.Key_Shift:
+            self._shift_held = pressed
+
+    def _zoom_axes_for_input(self, event_key=None, modifiers=None):
+        shift_active = self._shift_held
+        current_modifiers = Qt.KeyboardModifier.NoModifier
+        try:
+            current_modifiers = QApplication.queryKeyboardModifiers()
+        except Exception:
+            try:
+                current_modifiers = QApplication.keyboardModifiers()
+            except Exception:
+                current_modifiers = Qt.KeyboardModifier.NoModifier
+        combined_modifiers = current_modifiers
+        if modifiers is not None:
+            combined_modifiers = combined_modifiers | modifiers
+        if combined_modifiers & Qt.KeyboardModifier.ShiftModifier:
+            shift_active = True
+        if isinstance(event_key, str) and "shift" in event_key.lower():
+            shift_active = True
+        return (not shift_active, shift_active)
+
+    def _widget_pos_to_data(self, pointf):
+        if pointf is None:
+            return None, None
+        ratio = self._canvas.devicePixelRatio()
+        px_x = float(pointf.x()) * ratio
+        px_y = (self._canvas.height() - float(pointf.y())) * ratio
+        try:
+            cx, cy = self._ax.transData.inverted().transform((px_x, px_y))
+        except Exception:
+            return None, None
+        return cx, cy
+
+    def _begin_zoom_gesture(self):
+        now = time.monotonic()
+        if now - self._last_zoom_ts > 0.35:
+            self._push_undo_state()
+        self._last_zoom_ts = now
+
+    def _apply_zoom_from_input(self, scale_factor, cx, cy, modifiers=None, event_key=None):
+        if cx is None or cy is None or scale_factor is None or scale_factor <= 0:
             return
-        scale_factor = 0.85 if event.button == "up" else 1.15
-        self._push_undo_state()
-        self._apply_zoom(scale_factor, event.xdata, event.ydata, zoom_x=True, zoom_y=True)
+        zoom_x, zoom_y = self._zoom_axes_for_input(event_key=event_key, modifiers=modifiers)
+        self._apply_zoom(
+            scale_factor, cx, cy,
+            zoom_x=zoom_x, zoom_y=zoom_y,
+        )
+        self._last_zoom_ts = time.monotonic()
+
+    def _smooth_zoom_factor(self, scale_factor, *, deadband=0.006, clamp=0.12):
+        if scale_factor is None or scale_factor <= 0:
+            return None
+        delta = scale_factor - 1.0
+        if abs(delta) < deadband:
+            return None
+        delta = max(-clamp, min(clamp, delta))
+        return 1.0 + delta
+
+    def _scale_factor_from_wheel_event(self, event):
+        if event is None:
+            return None
+        use_pixel_delta = not event.pixelDelta().isNull()
+        app = QApplication.instance()
+        if app is not None and app.platformName() == "xcb":
+            use_pixel_delta = False
+        delta = event.pixelDelta() if use_pixel_delta else event.angleDelta()
+        dx = float(delta.x())
+        dy = float(delta.y())
+        dominant = dy if abs(dy) >= abs(dx) else dx
+        if abs(dominant) < 1e-6:
+            return None
+        steps = abs(dominant if use_pixel_delta else (dominant / 120.0))
+        base_zoom = 0.985 if use_pixel_delta else 0.965
+        if dominant > 0:
+            raw = base_zoom ** steps
+        else:
+            raw = (1.0 / base_zoom) ** steps
+        return self._smooth_zoom_factor(raw, deadband=0.004, clamp=0.16)
 
     def _apply_zoom(self, scale_factor, cx, cy, zoom_x=True, zoom_y=True):
         """Apply zoom centered on (cx, cy) with strict clamping."""
@@ -1735,9 +2035,9 @@ class LapTimeChartWindow(PitWallWindow):
         # Minimum zoom: 3 laps wide, 1.5 seconds tall
         if zoom_x and (new_x_hi - new_x_lo) < 3:
             return
-        if zoom_y and self._y_mode == "absolute" and (new_y_hi - new_y_lo) < 1.5:
+        if zoom_y and self._is_time_mode() and (new_y_hi - new_y_lo) < 1.5:
             return
-        if zoom_y and self._y_mode == "gap" and (new_y_hi - new_y_lo) < 0.5:
+        if zoom_y and self._is_gap_mode() and (new_y_hi - new_y_lo) < 0.5:
             return
 
         # Maximum zoom out: strictly clamp to home, no overshoot
@@ -1773,26 +2073,23 @@ class LapTimeChartWindow(PitWallWindow):
         if event.xdata is None or event.ydata is None:
             return
         if event.button == 1:
+            self._canvas.setFocus()
             if event.dblclick:
                 self._push_undo_state()
-                self._pan_press_px = None
-                self._pan_active = False
-                self._user_xlim = None
-                self._user_ylim = None
-                self._view_state_by_mode.pop(self._y_mode, None)
-                self._redraw()
+                self._reset_view()
             else:
-                self._push_undo_state()
                 self._pan_press_px = (event.x, event.y)
                 self._pan_origin_xlim = self._ax.get_xlim()
                 self._pan_origin_ylim = self._ax.get_ylim()
-                self._pan_active = True
+                self._pan_active = False
 
     def _on_button_release(self, event):
         """End pan on left-click release."""
         if event.button == 1:
             self._pan_press_px = None
             self._pan_active = False
+            self._last_pan_draw_ts = 0.0
+            self._canvas.unsetCursor()
 
     def _on_pick(self, event):
         """Toggle isolation when clicking a driver's legend."""
@@ -1826,41 +2123,75 @@ class LapTimeChartWindow(PitWallWindow):
             self._redraw()
 
     def eventFilter(self, obj, event):
-        """Handle Qt pinch gesture for trackpad zoom."""
+        """Handle Qt wheel and gesture zoom directly for consistent UX."""
         if event.type() == QEvent.Type.KeyPress:
+            self._update_modifier_latch(event, True)
             if self._handle_ui_key_event(event):
                 return True
-        if event.type() == QEvent.Type.Gesture:
+        if event.type() == QEvent.Type.KeyRelease:
+            self._update_modifier_latch(event, False)
+        if event.type() == QEvent.Type.Wheel and obj is self._canvas:
+            cx, cy = self._widget_pos_to_data(event.position())
+            if cx is None or cy is None:
+                return False
+            self._begin_zoom_gesture()
+            scale_factor = self._scale_factor_from_wheel_event(event)
+            self._apply_zoom_from_input(scale_factor, cx, cy, modifiers=event.modifiers())
+            return True
+        if self._use_native_pinch_zoom and event.type() == QEvent.Type.NativeGesture and obj is self._canvas:
+            gesture_type = event.gestureType()
+            if gesture_type == Qt.NativeGestureType.BeginNativeGesture:
+                self._begin_zoom_gesture()
+                return True
+            if gesture_type == Qt.NativeGestureType.EndNativeGesture:
+                return True
+            if gesture_type == Qt.NativeGestureType.ZoomNativeGesture:
+                cx, cy = self._widget_pos_to_data(event.position())
+                if cx is None or cy is None:
+                    return False
+                if self._last_zoom_ts == 0.0:
+                    self._begin_zoom_gesture()
+                scale_delta = 1.0 + float(event.value())
+                if scale_delta <= 0.0:
+                    return True
+                zoom_factor = self._smooth_zoom_factor(1.0 / scale_delta, deadband=0.0035, clamp=0.10)
+                self._apply_zoom_from_input(zoom_factor, cx, cy, modifiers=event.modifiers())
+                return True
+        if (not self._use_native_pinch_zoom) and event.type() == QEvent.Type.Gesture:
             pinch = event.gesture(Qt.GestureType.PinchGesture)
             if pinch:
-                scale = pinch.scaleFactor()
-                if scale != 1.0:
-                    # Convert pinch to zoom: spread out = zoom in
-                    center = pinch.centerPoint()
-                    # Map widget coords to axes data coords
-                    pos = self._canvas.mapFromGlobal(center.toPoint())
-                    inv = self._ax.transData.inverted()
-                    
-                    # Handle Retina / high-DPI scaling
-                    ratio = self._canvas.devicePixelRatio()
-                    px_x = pos.x() * ratio
-                    px_y = (self._canvas.height() - pos.y()) * ratio
-                    
-                    cx, cy = inv.transform((px_x, px_y))
-                    
-                    # Invert: scale > 1 = spread = zoom in = shrink factor
-                    zoom_factor = 1.0 / scale
-                    self._apply_zoom(zoom_factor, cx, cy)
+                state = pinch.state()
+                if state == Qt.GestureState.GestureStarted:
+                    self._begin_zoom_gesture()
+                if state == Qt.GestureState.GestureFinished:
+                    return True
+                current_scale = float(pinch.scaleFactor())
+                last_scale = float(pinch.lastScaleFactor() or 1.0)
+                if last_scale <= 0.0:
+                    last_scale = 1.0
+                incremental_scale = current_scale / last_scale if current_scale > 0.0 else 1.0
+                zoom_factor = self._smooth_zoom_factor(1.0 / incremental_scale, deadband=0.0035, clamp=0.10)
+                if zoom_factor is not None:
+                    cx, cy = self._widget_pos_to_data(pinch.centerPoint())
+                    self._apply_zoom_from_input(zoom_factor, cx, cy)
                 return True
         return super().eventFilter(obj, event)
 
     def keyPressEvent(self, event):
+        self._update_modifier_latch(event, True)
         if self._handle_ui_key_event(event):
             return
         super().keyPressEvent(event)
 
+    def keyReleaseEvent(self, event):
+        self._update_modifier_latch(event, False)
+        super().keyReleaseEvent(event)
+
     def _handle_ui_key_event(self, event):
         key = event.key()
+        if key in (Qt.Key.Key_K, Qt.Key.Key_L):
+            event.accept()
+            return True
         if key == Qt.Key.Key_H:
             self._toggle_help()
             event.accept()
@@ -1871,6 +2202,29 @@ class LapTimeChartWindow(PitWallWindow):
             self._redraw()
             event.accept()
             return True
+        if self._canvas.hasFocus():
+            pan_step_x = 0.12
+            pan_step_y = 0.10
+            if key == Qt.Key.Key_Left:
+                self._push_undo_state()
+                self._pan_view_by_fraction(frac_x=-pan_step_x)
+                event.accept()
+                return True
+            if key == Qt.Key.Key_Right:
+                self._push_undo_state()
+                self._pan_view_by_fraction(frac_x=pan_step_x)
+                event.accept()
+                return True
+            if key == Qt.Key.Key_Up:
+                self._push_undo_state()
+                self._pan_view_by_fraction(frac_y=pan_step_y)
+                event.accept()
+                return True
+            if key == Qt.Key.Key_Down:
+                self._push_undo_state()
+                self._pan_view_by_fraction(frac_y=-pan_step_y)
+                event.accept()
+                return True
         return False
 
     def on_connection_status_changed(self, status):
@@ -1882,7 +2236,7 @@ class LapTimeChartWindow(PitWallWindow):
 
 def main():
     app = QApplication(sys.argv)
-    app.setApplicationName("Lap Time Evolution")
+    app.setApplicationName("Lap Time & Gap Evolution")
     window = LapTimeChartWindow()
     window.show()
     sys.exit(app.exec())

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -214,6 +214,18 @@ def _entry_is_outlier(entry, pit_threshold):
     )
 
 
+def _is_clean_timed_entry(entry, pit_threshold, sc_vsc_laps):
+    if not entry:
+        return False
+    return (
+        0 < entry.get("time_s", -1) <= pit_threshold
+        and entry.get("lap") not in sc_vsc_laps
+        and not _entry_is_pit_affected(entry, pit_threshold)
+        and not _entry_is_out_lap(entry)
+        and not _entry_is_outlier(entry, pit_threshold)
+    )
+
+
 def _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps):
     if not entry:
         return False
@@ -224,6 +236,26 @@ def _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps):
         or _entry_is_outlier(entry, pit_threshold)
         or (lap in sc_vsc_laps if lap is not None else False)
     )
+
+
+def _legend_state_slot(entry):
+    if not entry:
+        return ""
+    if entry.get("is_terminal_lap") and entry.get("result_status"):
+        return "RET"
+    if _entry_is_pit_entry(entry):
+        return "PITS"
+    tyre = entry.get("tyre", -1)
+    tyre_name = get_tyre_compound_str(tyre)
+    if not tyre_name:
+        return ""
+    tyre_char = tyre_name[0].upper()
+    tyre_life = entry.get("tyre_life")
+    if isinstance(tyre_life, (int, float)) and tyre_life >= 0:
+        tyre_life_int = int(tyre_life)
+        if tyre_life_int > 0:
+            return f"{tyre_char}{tyre_life_int:02d}"
+    return tyre_char
 
 
 class LapTimeChartWindow(PitWallWindow):
@@ -250,6 +282,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._legend_text_by_code = {}
         self._legend_line_style_by_code = {}
         self._legend_text_style_by_code = {}
+        self._legend_bbox = None
+        self._legend_hitboxes = []
         self._plot_line_by_code = {}
         self._plot_line_style_by_code = {}
         self._hover_legend_code = None
@@ -290,6 +324,9 @@ class LapTimeChartWindow(PitWallWindow):
         self._deferred_redraw_timer = QTimer(self)
         self._deferred_redraw_timer.setSingleShot(True)
         self._deferred_redraw_timer.timeout.connect(self._flush_deferred_redraw)
+        self._resize_refresh_timer = QTimer(self)
+        self._resize_refresh_timer.setSingleShot(True)
+        self._resize_refresh_timer.timeout.connect(self._refresh_after_resize)
 
         self.setWindowTitle("F1 Race Replay - Lap Time & Gap Evolution")
         self.setGeometry(120, 120, 1000, 600)
@@ -307,6 +344,8 @@ class LapTimeChartWindow(PitWallWindow):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._reposition_overlays()
+        if getattr(self, "_has_ever_drawn", False):
+            self._resize_refresh_timer.start(30)
 
     def _reposition_overlays(self):
         """Keep the help overlay centered."""
@@ -314,6 +353,14 @@ class LapTimeChartWindow(PitWallWindow):
             hx = (self._canvas.width() - self._help_overlay.width()) // 2
             hy = (self._canvas.height() - self._help_overlay.height()) // 2
             self._help_overlay.move(max(0, hx), max(0, hy))
+
+    def _refresh_after_resize(self):
+        if not hasattr(self, "_canvas") or not getattr(self, "_has_ever_drawn", False):
+            return
+        self._canvas.draw()
+        self._rebuild_legend_hitboxes()
+        self._rebuild_hover_screen_cache()
+        self._refresh_hover_from_cursor()
 
     def _gap_ref_s(self, entry):
         if not entry:
@@ -656,17 +703,16 @@ class LapTimeChartWindow(PitWallWindow):
             self._view_state_by_mode.clear()
 
         # Ingest pre-computed data from server
-        server_lap_times = data.get("lap_times")
-        if server_lap_times:
+        if "lap_times" in data:
+            server_lap_times = data.get("lap_times")
             # Only flag for redraw if data actually changed
             if server_lap_times is not self._lap_times:
                 self._lap_times = server_lap_times
                 if not self._has_ever_drawn:
                     self._needs_full_redraw = True
 
-        server_status_laps = data.get("status_laps")
-        if server_status_laps:
-            self._status_laps = server_status_laps
+        if "status_laps" in data:
+            self._status_laps = data.get("status_laps") or []
 
         # Update driver list
         self._refresh_driver_list(drivers)
@@ -676,7 +722,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._last_drawn_lap = self._leader_lap
             force_redraw = self._needs_full_redraw
             self._needs_full_redraw = False
-            if not force_redraw and self._is_interaction_hot():
+            if not force_redraw and (self._is_interaction_hot() or self._hover_legend_code is not None):
                 self._pending_live_redraw = True
                 self._schedule_deferred_redraw()
             else:
@@ -836,6 +882,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._legend_text_by_code = {}
         self._legend_line_style_by_code = {}
         self._legend_text_style_by_code = {}
+        self._legend_bbox = None
+        self._legend_hitboxes = []
         self._plot_line_by_code = {}
         self._plot_line_style_by_code = {}
         self._hover_legend_code = None
@@ -1133,27 +1181,21 @@ class LapTimeChartWindow(PitWallWindow):
         driver_stints_text = {}
         display_y_vals = []
         all_axis_y_vals = []
+        legend_slot_by_code = {}
 
         session_best = float("inf")
-        session_best_code = None
         for code_sb, entries in visible_data.items():
             for e in entries:
-                if (
-                    0 < e["time_s"] <= pit_threshold
-                    and e["lap"] not in sc_vsc_laps
-                    and not _entry_is_pit_affected(e, pit_threshold)
-                    and not _entry_is_out_lap(e)
-                    and not _entry_is_outlier(e, pit_threshold)
-                ):
+                if _is_clean_timed_entry(e, pit_threshold, sc_vsc_laps):
                     if e["time_s"] < session_best:
                         session_best = e["time_s"]
-                        session_best_code = code_sb
         self._cached_session_best = session_best
-        self._cached_session_best_code = session_best_code
         self._cached_driver_personal_bests = {}
 
         for code, entries in visible_data.items():
             colour = self._driver_colors.get(code, _DEFAULT_COLOUR)
+            if entries:
+                legend_slot_by_code[code] = _legend_state_slot(entries[-1])
 
             if focus:
                 is_focused = code in focus
@@ -1168,19 +1210,13 @@ class LapTimeChartWindow(PitWallWindow):
                 show_detail = True
 
             clean_laps, clean_vals, clean_time_s, clean_tyres = [], [], [], []
-            pit_laps, pit_vals = [], []
+            pit_laps = []
             all_laps, all_vals, all_markers, all_marker_colours = [], [], [], []
             terminal_no_time_laps = []
             
             drv_clean_times = [
                 e["time_s"] for e in entries
-                if (
-                    0 < e["time_s"] <= pit_threshold
-                    and e["lap"] not in sc_vsc_laps
-                    and not _entry_is_pit_affected(e, pit_threshold)
-                    and not _entry_is_out_lap(e)
-                    and not _entry_is_outlier(e, pit_threshold)
-                )
+                if _is_clean_timed_entry(e, pit_threshold, sc_vsc_laps)
             ]
             personal_best = min(drv_clean_times) if drv_clean_times else float("inf")
             self._cached_driver_personal_bests[code] = personal_best
@@ -1203,7 +1239,6 @@ class LapTimeChartWindow(PitWallWindow):
                     if val is None:
                         if is_pit_entry:
                             pit_laps.append(lap)
-                            pit_vals.append(0)
                         continue
                 else:
                     if raw_time < 0:
@@ -1211,7 +1246,6 @@ class LapTimeChartWindow(PitWallWindow):
                             terminal_no_time_laps.append(lap)
                         if is_pit_entry:
                             pit_laps.append(lap)
-                            pit_vals.append(0) # Dummy value, won't be plotted on main line
                         continue
                     val = raw_time
                     
@@ -1223,7 +1257,6 @@ class LapTimeChartWindow(PitWallWindow):
                 if is_pit_entry:
                     # Explicit pit stop (In-Lap)
                     pit_laps.append(lap)
-                    pit_vals.append(val)
                 elif is_out_lap or is_outlier:
                     # Just a really slow lap (like a standing start or an Out-Lap).
                     # Ignore it completely so it doesn't squish the Y-axis.
@@ -1377,13 +1410,7 @@ class LapTimeChartWindow(PitWallWindow):
                 # Calculate best lap and avg true pace
                 drv_clean_times = [
                     e["time_s"] for e in visible_data[code] 
-                    if (
-                        e["time_s"] <= pit_threshold
-                        and e["lap"] not in sc_vsc_laps
-                        and not _entry_is_pit_affected(e, pit_threshold)
-                        and not _entry_is_out_lap(e)
-                        and not _entry_is_outlier(e, pit_threshold)
-                    )
+                    if _is_clean_timed_entry(e, pit_threshold, sc_vsc_laps)
                 ]
                 # Count actual pit stops (group consecutive in/out laps)
                 pit_laps = [e["lap"] for e in visible_data[code] if _entry_is_pit_entry(e)]
@@ -1453,7 +1480,12 @@ class LapTimeChartWindow(PitWallWindow):
         # ── 6. Interactive legend (click to isolate) ──
         handles, labels = ax.get_legend_handles_labels()
         if handles and self._legend_visible:
+            display_labels = []
+            for code in labels:
+                indicator = legend_slot_by_code.get(code, "")
+                display_labels.append(f"{code:<3}  {indicator:<4}")
             leg = ax.legend(
+                handles, display_labels,
                 loc="upper right", fontsize=7, framealpha=0.6,
                 facecolor=_BG, edgecolor="#555555", labelcolor=_TEXT,
                 ncol=2 if len(handles) > 10 else 1,
@@ -1472,6 +1504,7 @@ class LapTimeChartWindow(PitWallWindow):
                 }
             for leg_text, orig_label in zip(leg.get_texts(), labels):
                 leg_text.set_picker(True)
+                leg_text.set_fontfamily("monospace")
                 self._legend_map[leg_text] = orig_label
                 self._legend_text_by_code[orig_label] = leg_text
                 self._legend_text_style_by_code[orig_label] = {
@@ -1479,6 +1512,7 @@ class LapTimeChartWindow(PitWallWindow):
                     "fontweight": leg_text.get_fontweight(),
                     "alpha": 1.0 if leg_text.get_alpha() is None else float(leg_text.get_alpha()),
                 }
+            self._rebuild_legend_hitboxes()
             ax.add_artist(leg)
             if previous_hover_legend_code in self._legend_line_by_code or previous_hover_legend_code in self._legend_text_by_code:
                 self._hover_legend_code = previous_hover_legend_code
@@ -1768,20 +1802,18 @@ class LapTimeChartWindow(PitWallWindow):
                 self._hide_hover()
 
     def _is_over_legend(self, event):
-        legend = getattr(self, "_legend_artist", None)
-        if legend is None:
-            return False
-        try:
-            bbox = legend.get_window_extent(self._canvas.renderer)
-        except Exception:
-            return False
-        return bbox.contains(event.x, event.y)
+        bbox = getattr(self, "_legend_bbox", None)
+        return bool(bbox is not None and bbox.contains(event.x, event.y))
 
     def _hovered_legend_code(self, event):
         if not getattr(self, "_legend_map", None):
             return None
         if event is None:
             return None
+        hitboxes = getattr(self, "_legend_hitboxes", None) or []
+        for bbox, code in hitboxes:
+            if bbox.contains(event.x, event.y):
+                return code
         for artist, code in self._legend_map.items():
             try:
                 contains, _ = artist.contains(event)
@@ -1796,6 +1828,33 @@ class LapTimeChartWindow(PitWallWindow):
             if bbox is not None and bbox.expanded(1.08, 1.25).contains(event.x, event.y):
                 return code
         return None
+
+    def _rebuild_legend_hitboxes(self):
+        self._legend_bbox = None
+        self._legend_hitboxes = []
+        legend = getattr(self, "_legend_artist", None)
+        if legend is None:
+            return
+        renderer = getattr(self._canvas, "renderer", None)
+        if renderer is None:
+            try:
+                renderer = self._canvas.get_renderer()
+            except Exception:
+                renderer = None
+        if renderer is None:
+            return
+        try:
+            self._legend_bbox = legend.get_window_extent(renderer)
+        except Exception:
+            self._legend_bbox = None
+        for artist, code in getattr(self, "_legend_map", {}).items():
+            try:
+                bbox = artist.get_window_extent(renderer)
+            except Exception:
+                continue
+            if bbox is None:
+                continue
+            self._legend_hitboxes.append((bbox.expanded(1.08, 1.25), code))
 
     def _set_legend_hover_code(self, code):
         if code == self._hover_legend_code:
@@ -1974,15 +2033,23 @@ class LapTimeChartWindow(PitWallWindow):
         self._canvas.draw_idle()
 
     def _hide_hover(self):
+        changed = False
         if self._annot:
-            self._annot.set_visible(False)
+            if self._annot.get_visible():
+                self._annot.set_visible(False)
+                changed = True
         if self._crosshair_v:
-            self._crosshair_v.set_visible(False)
+            if self._crosshair_v.get_visible():
+                self._crosshair_v.set_visible(False)
+                changed = True
         if self._crosshair_h:
-            self._crosshair_h.set_visible(False)
+            if self._crosshair_h.get_visible():
+                self._crosshair_h.set_visible(False)
+                changed = True
         self._last_crosshair_state = None
         self._hover_point_key = None
-        self._canvas.draw_idle()
+        if changed:
+            self._canvas.draw_idle()
 
     def _rebuild_hover_screen_cache(self):
         hover_candidates = getattr(self, "_cached_hover_candidates", None)
@@ -2024,7 +2091,7 @@ class LapTimeChartWindow(PitWallWindow):
         )
 
     def _schedule_deferred_redraw(self):
-        self._deferred_redraw_timer.start(140)
+        self._deferred_redraw_timer.start(110 if self._hover_legend_code is not None else 140)
 
     def _flush_deferred_redraw(self):
         if not self._pending_live_redraw:
@@ -2197,6 +2264,7 @@ class LapTimeChartWindow(PitWallWindow):
             
             self._needs_full_redraw = True
             self._redraw()
+            QTimer.singleShot(0, self._refresh_hover_from_cursor)
 
     def eventFilter(self, obj, event):
         """Handle Qt wheel and gesture zoom directly for consistent UX."""

--- a/src/insights/lap_time_chart_window.py
+++ b/src/insights/lap_time_chart_window.py
@@ -23,6 +23,7 @@ import time
 import numpy as np
 import matplotlib
 matplotlib.use("QtAgg")
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -241,8 +242,56 @@ def _entry_has_gap_discontinuity(entry, pit_threshold, sc_vsc_laps):
 def _terminal_status_display_text(status):
     status_text = str(status or "").strip()
     if not status_text or status_text.lower() == "retired":
-        return "Retired due to DNF"
+        return "Retired (DNF)"
     return status_text
+
+
+class _OverlayBlitManager:
+    """Manage a tiny animated overlay layer for hover crosshair and tooltip."""
+
+    def __init__(self, canvas):
+        self.canvas = canvas
+        self.enabled = bool(getattr(canvas, "supports_blit", False))
+        self._artists = []
+        self._background = None
+        self._cid = canvas.mpl_connect("draw_event", self._on_draw)
+
+    def set_artists(self, artists):
+        self._artists = [artist for artist in artists if artist is not None]
+        if self.enabled:
+            for artist in self._artists:
+                artist.set_animated(True)
+
+    def reset(self):
+        self._background = None
+
+    def _on_draw(self, event):
+        if not self.enabled:
+            return
+        try:
+            self._background = self.canvas.copy_from_bbox(self.canvas.figure.bbox)
+            self._draw_artists()
+            self.canvas.blit(self.canvas.figure.bbox)
+        except Exception:
+            self._background = None
+
+    def _draw_artists(self):
+        fig = self.canvas.figure
+        for artist in self._artists:
+            if artist is not None and artist.get_visible():
+                fig.draw_artist(artist)
+
+    def update(self):
+        if not self.enabled or self._background is None:
+            return False
+        try:
+            self.canvas.restore_region(self._background)
+            self._draw_artists()
+            self.canvas.blit(self.canvas.figure.bbox)
+            return True
+        except Exception:
+            self._background = None
+            return False
 
 
 class LapTimeChartWindow(PitWallWindow):
@@ -306,16 +355,38 @@ class LapTimeChartWindow(PitWallWindow):
         # Crosshair debounce
         self._last_crosshair_state = None
         self._hover_point_key = None
-        self._last_rendered_terminal_signature = ()
+        self._last_rendered_visibility_signature = ()
+        self._chart_dirty = False
+        self._render_in_flight = False
+        self._last_render_monotonic = 0.0
+        self._latest_stream_version = 0
+        self._last_rendered_stream_version = 0
+        self._resize_active = False
+        self._resize_started_monotonic = None
+        self._hover_cache_dirty = False
+        self._debug_perf_enabled = False
+        self._perf_stats = {
+            "full_redraw_count": 0,
+            "coalesced_live_updates": 0,
+            "redraw_durations_ms": [],
+            "resize_freeze_ms": 0.0,
+        }
+        self._overlay_blit = None
 
         super().__init__()
 
         self._deferred_redraw_timer = QTimer(self)
         self._deferred_redraw_timer.setSingleShot(True)
         self._deferred_redraw_timer.timeout.connect(self._flush_deferred_redraw)
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.timeout.connect(self._flush_live_render)
         self._resize_refresh_timer = QTimer(self)
         self._resize_refresh_timer.setSingleShot(True)
         self._resize_refresh_timer.timeout.connect(self._refresh_after_resize)
+        self._view_refresh_timer = QTimer(self)
+        self._view_refresh_timer.setSingleShot(True)
+        self._view_refresh_timer.timeout.connect(self._refresh_after_view_change)
 
         self.setWindowTitle("F1 Race Replay - Lap Time & Gap Evolution")
         self.setGeometry(120, 120, 1000, 600)
@@ -344,11 +415,37 @@ class LapTimeChartWindow(PitWallWindow):
                 return float(value)
         return None
 
+    def _entry_completion_visibility_time_s(self, entry):
+        if not entry or entry.get("is_terminal_lap"):
+            return None
+        for key in ("replay_line_time_s", "replay_end_time_s"):
+            value = entry.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+        if entry.get("time_source") == "frame_backfill" or entry.get("source") == "derived":
+            for key in ("line_time_s", "end_time_s"):
+                value = entry.get(key)
+                if isinstance(value, (int, float)):
+                    return float(value)
+        return None
+
+    def _is_normal_entry_visible(self, entry):
+        if not entry or entry.get("is_terminal_lap"):
+            return False
+        visible_at_s = self._entry_completion_visibility_time_s(entry)
+        if visible_at_s is not None and isinstance(self._current_time_s, (int, float)):
+            return self._current_time_s >= visible_at_s
+        lap = entry.get("lap")
+        if isinstance(lap, (int, float)):
+            lap_int = int(lap)
+            if self._total_laps and lap_int >= int(self._total_laps):
+                return False
+            return self._leader_lap > lap_int
+        return False
+
     def _is_terminal_entry_visible(self, entry, include_final=False):
         if not entry or not entry.get("is_terminal_lap"):
             return False
-        if include_final:
-            return True
         visible_at_s = self._terminal_entry_visibility_time_s(entry)
         if visible_at_s is not None and isinstance(self._current_time_s, (int, float)):
             return self._current_time_s >= visible_at_s
@@ -357,29 +454,29 @@ class LapTimeChartWindow(PitWallWindow):
             return self._leader_lap > int(lap)
         return False
 
-    def _terminal_visibility_signature(self):
+    def _visible_entry_signature(self):
         if not self._lap_times:
             return ()
-        include_final = bool(self._total_laps and self._leader_lap >= self._total_laps)
         visible = []
         for code, entries in self._lap_times.items():
             for entry in entries:
-                if self._is_terminal_entry_visible(entry, include_final=include_final):
-                    visible.append((code, int(entry.get("lap", -1))))
+                if entry.get("is_terminal_lap"):
+                    if self._is_terminal_entry_visible(entry, include_final=False):
+                        visible.append((code, int(entry.get("lap", -1)), "terminal"))
+                elif self._is_normal_entry_visible(entry):
+                    visible.append((code, int(entry.get("lap", -1)), "lap"))
         return tuple(sorted(visible))
-
-    def _completed_lap_cutoff(self):
-        include_final = bool(self._total_laps and self._leader_lap >= self._total_laps)
-        if include_final:
-            return max(0, int(self._leader_lap))
-        return max(0, int(self._leader_lap) - 1)
         
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._reposition_overlays()
         if getattr(self, "_has_ever_drawn", False):
-            self._resize_refresh_timer.start(30)
+            if not self._resize_active:
+                self._resize_active = True
+                self._resize_started_monotonic = time.monotonic()
+            self._view_refresh_timer.stop()
+            self._resize_refresh_timer.start(140)
 
     def _reposition_overlays(self):
         """Keep the help overlay centered."""
@@ -391,10 +488,63 @@ class LapTimeChartWindow(PitWallWindow):
     def _refresh_after_resize(self):
         if not hasattr(self, "_canvas") or not getattr(self, "_has_ever_drawn", False):
             return
-        self._canvas.draw()
-        self._rebuild_legend_hitboxes()
+        if self._resize_active and self._resize_started_monotonic is not None:
+            self._perf_stats["resize_freeze_ms"] += (time.monotonic() - self._resize_started_monotonic) * 1000.0
+        self._resize_active = False
+        self._resize_started_monotonic = None
+        self._overlay_reset()
+        self._mark_chart_dirty()
+        self._request_live_render(immediate=True)
+
+    def _refresh_after_view_change(self):
+        if self._resize_active or not getattr(self, "_has_ever_drawn", False):
+            return
+        self._hover_cache_dirty = False
         self._rebuild_hover_screen_cache()
         self._refresh_hover_from_cursor()
+
+    def _invalidate_hover_screen_cache(self, refresh_delay_ms=80):
+        self._hover_cache_dirty = True
+        self._view_refresh_timer.start(refresh_delay_ms)
+
+    def _overlay_reset(self):
+        if self._overlay_blit is not None:
+            self._overlay_blit.reset()
+
+    def _overlay_update(self):
+        if self._overlay_blit is not None and self._overlay_blit.update():
+            return
+        self._canvas.draw_idle()
+
+    def _mark_chart_dirty(self):
+        self._chart_dirty = True
+
+    def _target_render_interval_ms(self):
+        if self._hover_legend_code is not None:
+            return 280
+        if self._is_interaction_hot():
+            return 100
+        return 50
+
+    def _request_live_render(self, immediate=False):
+        self._mark_chart_dirty()
+        if self._resize_active:
+            return
+        if immediate:
+            if self._render_timer.isActive():
+                self._render_timer.stop()
+            self._flush_live_render()
+            return
+        interval_ms = self._target_render_interval_ms()
+        elapsed_ms = (time.monotonic() - self._last_render_monotonic) * 1000.0 if self._last_render_monotonic else None
+        if elapsed_ms is None or elapsed_ms >= interval_ms:
+            delay_ms = 0
+        else:
+            delay_ms = max(0, int(interval_ms - elapsed_ms))
+        if self._render_timer.isActive():
+            self._perf_stats["coalesced_live_updates"] += 1
+            return
+        self._render_timer.start(delay_ms)
 
     def _gap_ref_s(self, entry):
         if not entry:
@@ -606,6 +756,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._canvas.sizePolicy().horizontalPolicy(),
             self._canvas.sizePolicy().verticalPolicy(),
         )
+        self._overlay_blit = _OverlayBlitManager(self._canvas)
         root.addWidget(self._canvas, stretch=1)
 
         # Connect mouse events: crosshair, legend/line pick, drag-pan
@@ -698,6 +849,7 @@ class LapTimeChartWindow(PitWallWindow):
     # Telemetry handling
 
     def on_telemetry_data(self, data):
+        self._latest_stream_version += 1
         frame = data.get("frame")
         if not frame:
             return
@@ -738,7 +890,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._user_xlim = None
             self._user_ylim = None
             self._view_state_by_mode.clear()
-            self._last_rendered_terminal_signature = ()
+            self._last_rendered_visibility_signature = ()
 
         # Ingest pre-computed data from server
         if "lap_times" in data:
@@ -755,22 +907,25 @@ class LapTimeChartWindow(PitWallWindow):
         # Update driver list
         self._refresh_driver_list(drivers)
 
-        terminal_visibility_changed = (
-            self._terminal_visibility_signature() != self._last_rendered_terminal_signature
+        visible_entries_changed = (
+            self._visible_entry_signature() != self._last_rendered_visibility_signature
         )
 
         # Redraw when leader crosses a new lap, terminal state becomes visible,
         # or the chart needs a full rebuild.
-        if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw or terminal_visibility_changed:
+        if self._leader_lap > self._last_drawn_lap or self._needs_full_redraw or visible_entries_changed:
             self._last_drawn_lap = self._leader_lap
             force_redraw = self._needs_full_redraw
             self._needs_full_redraw = False
-            if not force_redraw and (self._is_interaction_hot() or self._hover_legend_code is not None):
-                self._pending_live_redraw = True
-                self._schedule_deferred_redraw()
-            else:
+            if not self._has_ever_drawn:
                 self._pending_live_redraw = False
-                self._redraw()
+                self._redraw_now()
+            elif force_redraw and not self._resize_active:
+                self._pending_live_redraw = False
+                self._request_live_render(immediate=True)
+            else:
+                self._pending_live_redraw = True
+                self._request_live_render(immediate=False)
 
     def _refresh_driver_list(self, drivers):
         incoming = sorted(drivers.keys())
@@ -799,7 +954,7 @@ class LapTimeChartWindow(PitWallWindow):
         else:
             self._focused_drivers = {text}
         self._needs_full_redraw = True
-        self._redraw()
+        self._redraw_now()
 
     def _on_ymode_changed(self, index):
         self._push_undo_state()
@@ -807,7 +962,7 @@ class LapTimeChartWindow(PitWallWindow):
         self._y_mode = _YMODE_TIME if index == 0 else _YMODE_GAP
         self._restore_view_state()
         self._needs_full_redraw = True
-        self._redraw()
+        self._redraw_now()
 
     def _save_view_state(self):
         if not getattr(self, "_has_ever_drawn", False):
@@ -860,14 +1015,14 @@ class LapTimeChartWindow(PitWallWindow):
             self._user_xlim = tuple(snapshot["xlim"])
             self._user_ylim = tuple(snapshot["ylim"])
             self._needs_full_redraw = True
-            self._redraw()
+            self._redraw_now()
             self._update_history_buttons()
             return
         self._ax.set_xlim(snapshot["xlim"])
         self._ax.set_ylim(snapshot["ylim"])
         self._set_user_view(snapshot["xlim"], snapshot["ylim"])
-        self._rebuild_hover_screen_cache()
-        self._refresh_hover_from_cursor()
+        self._overlay_reset()
+        self._invalidate_hover_screen_cache(refresh_delay_ms=30)
         self._update_history_buttons()
         self._canvas.draw_idle()
 
@@ -899,7 +1054,23 @@ class LapTimeChartWindow(PitWallWindow):
 
     def _on_pure_pace_toggled(self, state):
         self._needs_full_redraw = True
-        self._redraw()
+        self._redraw_now()
+
+    def _redraw_now(self):
+        started = time.monotonic()
+        self._render_in_flight = True
+        try:
+            self._redraw()
+            self._chart_dirty = False
+            self._last_rendered_stream_version = self._latest_stream_version
+        finally:
+            elapsed_ms = (time.monotonic() - started) * 1000.0
+            self._last_render_monotonic = time.monotonic()
+            self._render_in_flight = False
+            self._perf_stats["full_redraw_count"] += 1
+            self._perf_stats["redraw_durations_ms"].append(elapsed_ms)
+            if len(self._perf_stats["redraw_durations_ms"]) > 120:
+                self._perf_stats["redraw_durations_ms"] = self._perf_stats["redraw_durations_ms"][-120:]
 
     def _toggle_help(self):
         if self._help_overlay.isHidden():
@@ -914,6 +1085,7 @@ class LapTimeChartWindow(PitWallWindow):
     def _redraw(self):
         ax = self._ax
         self._pending_live_redraw = False
+        self._overlay_reset()
         previous_hover_legend_code = self._hover_legend_code
         previous_hover_point_key = self._hover_point_key
         ax.clear()
@@ -937,23 +1109,18 @@ class LapTimeChartWindow(PitWallWindow):
 
         focus = self._focused_drivers
 
-        # Show completed laps during replay. Terminal no-time laps become visible
-        # only once the replay has actually reached their event timestamp.
+        # Show each driver's laps only once that driver actually completes them.
+        # Terminal no-time laps remain special event markers and become visible
+        # once the replay has reached their event timestamp.
         visible_data = {}
-        lap_cutoff = self._leader_lap
-        include_final_lap = self._total_laps and self._leader_lap >= self._total_laps
-        completed_lap_cutoff = self._completed_lap_cutoff()
         for code, entries in self._lap_times.items():
-            if include_final_lap:
-                visible = [e for e in entries if e["lap"] <= lap_cutoff or e.get("is_terminal_lap")]
-            else:
-                visible = []
-                for entry in entries:
-                    if entry.get("is_terminal_lap"):
-                        if self._is_terminal_entry_visible(entry, include_final=False):
-                            visible.append(entry)
-                    elif entry["lap"] < lap_cutoff:
+            visible = []
+            for entry in entries:
+                if entry.get("is_terminal_lap"):
+                    if self._is_terminal_entry_visible(entry, include_final=False):
                         visible.append(entry)
+                elif self._is_normal_entry_visible(entry):
+                    visible.append(entry)
             if visible:
                 visible_data[code] = visible
 
@@ -961,7 +1128,30 @@ class LapTimeChartWindow(PitWallWindow):
             self._canvas.draw_idle()
             return
 
+        completed_lap_cutoff = max(
+            (
+                int(entry["lap"])
+                for entries in visible_data.values()
+                for entry in entries
+                if not entry.get("is_terminal_lap")
+            ),
+            default=0,
+        )
+
         pure_pace = self._pure_pace_cb.isChecked()
+        # Gap mode should stay completed-lap based for rendering, but the
+        # fallback/interpolation math can safely use the full session-known
+        # lap set as anchor points. This prevents completed laps from popping
+        # in late simply because their next official anchor is only revealed
+        # on the chart one replay lap later.
+        gap_source_data = {}
+        for code, entries in self._lap_times.items():
+            source_entries = [
+                e for e in entries
+                if not e.get("is_terminal_lap")
+            ]
+            if source_entries:
+                gap_source_data[code] = source_entries
         sc_vsc_laps = set()
         
         # ── 1. Safety Car / VSC shaded zones ──
@@ -1006,11 +1196,11 @@ class LapTimeChartWindow(PitWallWindow):
         # data is inconsistent.
         lap_entry_lookup = {
             code: {e["lap"]: e for e in entries if e["time_s"] > 0}
-            for code, entries in visible_data.items()
+            for code, entries in gap_source_data.items()
         }
         leader_refs = {}
         if self._is_gap_mode():
-            for lap in sorted({e["lap"] for entries in visible_data.values() for e in entries}):
+            for lap in sorted({e["lap"] for entries in gap_source_data.values() for e in entries}):
                 official_candidates = []
                 candidates = []
                 for code, lap_entries in lap_entry_lookup.items():
@@ -1041,7 +1231,7 @@ class LapTimeChartWindow(PitWallWindow):
         gap_overrides = {}
         gap_suppressed_laps = set()
         if self._is_gap_mode():
-            for code, entries in visible_data.items():
+            for code, entries in gap_source_data.items():
                 sorted_entries = sorted(entries, key=lambda item: item["lap"])
                 anchors = []
                 for entry in sorted_entries:
@@ -1116,7 +1306,7 @@ class LapTimeChartWindow(PitWallWindow):
                         continue
                     gap_adjustments[(code, lap)] = adjusted_val
             gap_override_threshold = 5.0
-            for code, entries in visible_data.items():
+            for code, entries in gap_source_data.items():
                 sorted_entries = sorted(entries, key=lambda item: item["lap"])
                 prev_gap = None
                 prev_gap_lap = None
@@ -1225,6 +1415,14 @@ class LapTimeChartWindow(PitWallWindow):
 
         # Store line references for picking
         driver_stints_text = {}
+        pending_pit_markers = []
+        focused_hud_rows = min(len(focus), 4) if focus else 0
+        pit_marker_y_by_focus_rows = {
+            1: 0.88,
+            2: 0.83,
+            3: 0.78,
+            4: 0.73,
+        }
         display_y_vals = []
         all_axis_y_vals = []
 
@@ -1430,19 +1628,13 @@ class LapTimeChartWindow(PitWallWindow):
             # Only show when a driver is focused (in All Drivers view,
             # dozens of pit-lap outlier points create noise)
             if pit_laps and focus and is_focused and not pure_pace:
-                pit_marker_y_frac = 0.87 if len(focus) > 1 else 0.95
-                for pl in pit_laps:
-                    ax.axvline(
-                        pl, color=colour, alpha=0.55,
-                        linewidth=1.2, linestyle=":",
-                        zorder=zorder - 2,
-                    )
-                    ax.scatter(
-                        pl, pit_marker_y_frac, marker="x",
-                        color=colour, alpha=0.9, s=46,
-                        zorder=zorder, linewidths=1.8,
-                        transform=ax.get_xaxis_transform()
-                    )
+                pending_pit_markers.append({
+                    "code": code,
+                    "laps": list(pit_laps),
+                    "colour": colour,
+                    "zorder": zorder,
+                    "y_frac": pit_marker_y_by_focus_rows.get(focused_hud_rows, 0.87),
+                })
 
             if terminal_marker_entries and focus and is_focused and not pure_pace:
                 for item in terminal_marker_entries:
@@ -1466,7 +1658,6 @@ class LapTimeChartWindow(PitWallWindow):
         # ── 4b. HUD Statistics (prepared for drawing at the end) ──
         hud_handles, hud_labels = [], []
         if focus and len(focus) <= 4:
-            import matplotlib.lines as mlines
             for code in sorted(focus):
                 if code not in visible_data: continue
                 # Calculate best lap and avg true pace
@@ -1542,7 +1733,7 @@ class LapTimeChartWindow(PitWallWindow):
                     "is_pit_entry": point.get("is_pit_entry", False),
                     "is_approx": False,
                     "is_terminal_no_time": True,
-                    "status": point.get("status", "Retired due to DNF"),
+                    "status": point.get("status", "Retired (DNF)"),
                 })
 
         # X-axis
@@ -1598,6 +1789,24 @@ class LapTimeChartWindow(PitWallWindow):
                 facecolor=_BG, edgecolor="#555555", labelcolor=_TEXT
             )
             hud_leg.set_zorder(50)
+        else:
+            hud_leg = None
+
+        if pending_pit_markers:
+            for marker_info in pending_pit_markers:
+                pit_marker_y_frac = marker_info["y_frac"]
+                for pl in marker_info["laps"]:
+                    ax.axvline(
+                        pl, color=marker_info["colour"], alpha=0.55,
+                        linewidth=1.2, linestyle=":",
+                        zorder=marker_info["zorder"] - 2,
+                    )
+                    ax.scatter(
+                        pl, pit_marker_y_frac, marker="x",
+                        color=marker_info["colour"], alpha=0.9, s=46,
+                        zorder=marker_info["zorder"], linewidths=1.8,
+                        transform=ax.get_xaxis_transform()
+                    )
 
         # Setup crosshair annotation (hidden by default)
         self._annot = ax.annotate(
@@ -1613,6 +1822,8 @@ class LapTimeChartWindow(PitWallWindow):
         # Crosshair lines
         self._crosshair_v = ax.axvline(0, color="#555555", linewidth=0.5, linestyle="--", visible=False, zorder=99)
         self._crosshair_h = ax.axhline(0, color="#555555", linewidth=0.5, linestyle="--", visible=False, zorder=99)
+        if self._overlay_blit is not None:
+            self._overlay_blit.set_artists([self._annot, self._crosshair_v, self._crosshair_h])
 
 
         # Store home limits for zoom clamping
@@ -1651,11 +1862,16 @@ class LapTimeChartWindow(PitWallWindow):
         if self._user_ylim is not None:
             ax.set_ylim(self._user_ylim)
 
+        self._hover_cache_dirty = False
         self._rebuild_hover_screen_cache()
         self._has_ever_drawn = True
         self._last_crosshair_state = None
-        self._last_rendered_terminal_signature = self._terminal_visibility_signature()
-        if not self._restore_hover_point(previous_hover_point_key):
+        self._last_rendered_visibility_signature = self._visible_entry_signature()
+        legend_hover_restored = (
+            previous_hover_legend_code is not None
+            and self._hover_legend_code == previous_hover_legend_code
+        )
+        if not legend_hover_restored and not self._restore_hover_point(previous_hover_point_key):
             self._refresh_hover_from_cursor()
         self._canvas.draw_idle()
 
@@ -1758,7 +1974,8 @@ class LapTimeChartWindow(PitWallWindow):
         self._ax.set_ylim(new_y_lo, new_y_hi)
         self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
         self._mark_interaction_activity()
-        self._rebuild_hover_screen_cache()
+        self._overlay_reset()
+        self._invalidate_hover_screen_cache()
         self._canvas.draw_idle()
 
     def _reset_view(self):
@@ -1769,7 +1986,7 @@ class LapTimeChartWindow(PitWallWindow):
         self._user_ylim = None
         self._view_state_by_mode.pop(self._y_mode, None)
         self._canvas.unsetCursor()
-        self._redraw()
+        self._redraw_now()
 
     def _on_mouse_move(self, event):
         """Crosshair + tooltip on hover, and pixel-based drag-to-pan."""
@@ -1789,7 +2006,7 @@ class LapTimeChartWindow(PitWallWindow):
                 if self._crosshair_h:
                     self._crosshair_h.set_visible(False)
                 self._last_crosshair_state = None
-                self._canvas.draw_idle()
+                self._overlay_update()
             return
 
         if self._is_over_legend(event):
@@ -1833,7 +2050,7 @@ class LapTimeChartWindow(PitWallWindow):
                 self._ax.set_ylim(new_y_lo, new_y_hi)
                 self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
                 self._mark_interaction_activity()
-                self._rebuild_hover_screen_cache()
+                self._invalidate_hover_screen_cache()
                 self._last_pan_draw_ts = now
                 self._canvas.draw_idle()
                 return
@@ -1846,7 +2063,7 @@ class LapTimeChartWindow(PitWallWindow):
                     self._crosshair_v.set_visible(False)
                 if self._crosshair_h:
                     self._crosshair_h.set_visible(False)
-                self._canvas.draw_idle()
+                self._overlay_update()
             return
 
         hover_points = getattr(self, "_cached_hover_screen_points", None)
@@ -1932,10 +2149,21 @@ class LapTimeChartWindow(PitWallWindow):
             return
         if self._hover_legend_code is not None:
             self._apply_legend_hover_style(self._hover_legend_code, active=False)
+        entering_hover = code is not None and self._hover_legend_code is None
+        leaving_hover = code is None and self._hover_legend_code is not None
         self._hover_legend_code = code
+        if entering_hover:
+            if self._render_timer.isActive():
+                self._render_timer.stop()
+            if self._deferred_redraw_timer.isActive():
+                self._deferred_redraw_timer.stop()
         if code is not None:
             self._apply_legend_hover_style(code, active=True)
         self._canvas.draw_idle()
+        if entering_hover and (self._chart_dirty or self._pending_live_redraw or self._last_rendered_stream_version != self._latest_stream_version):
+            self._request_live_render(immediate=False)
+        if leaving_hover and (self._chart_dirty or self._pending_live_redraw or self._last_rendered_stream_version != self._latest_stream_version):
+            self._request_live_render(immediate=False)
 
     def _apply_legend_hover_style(self, code, active):
         plot_line = self._plot_line_by_code.get(code)
@@ -2100,7 +2328,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._crosshair_h.set_ydata([info["val"]])
             self._crosshair_h.set_visible(True)
 
-        self._canvas.draw_idle()
+        self._overlay_update()
 
     def _hide_hover(self):
         changed = False
@@ -2119,12 +2347,13 @@ class LapTimeChartWindow(PitWallWindow):
         self._last_crosshair_state = None
         self._hover_point_key = None
         if changed:
-            self._canvas.draw_idle()
+            self._overlay_update()
 
     def _rebuild_hover_screen_cache(self):
         hover_candidates = getattr(self, "_cached_hover_candidates", None)
         if not hover_candidates or not hasattr(self, "_ax"):
             self._cached_hover_screen_points = []
+            self._hover_cache_dirty = False
             return
         transform = self._ax.transData.transform
         screen_points = []
@@ -2135,9 +2364,15 @@ class LapTimeChartWindow(PitWallWindow):
                 continue
             screen_points.append((float(px), float(py), info))
         self._cached_hover_screen_points = screen_points
+        self._hover_cache_dirty = False
 
     def _refresh_hover_from_cursor(self):
-        if not hasattr(self, "_canvas") or not getattr(self, "_has_ever_drawn", False):
+        if (
+            not hasattr(self, "_canvas")
+            or not getattr(self, "_has_ever_drawn", False)
+            or self._hover_cache_dirty
+            or self._resize_active
+        ):
             return
         local_pos = self._canvas.mapFromGlobal(QCursor.pos())
         if not self._canvas.rect().contains(local_pos):
@@ -2164,13 +2399,33 @@ class LapTimeChartWindow(PitWallWindow):
         self._deferred_redraw_timer.start(110 if self._hover_legend_code is not None else 140)
 
     def _flush_deferred_redraw(self):
-        if not self._pending_live_redraw:
+        if self._pending_live_redraw:
+            self._request_live_render(immediate=False)
+
+    def _flush_live_render(self):
+        if not self._chart_dirty or self._resize_active or self._render_in_flight:
             return
         if self._is_interaction_hot():
             self._schedule_deferred_redraw()
             return
+        self._render_in_flight = True
         self._pending_live_redraw = False
-        self._redraw()
+        started = time.monotonic()
+        stream_version = self._latest_stream_version
+        try:
+            self._redraw()
+            self._chart_dirty = False
+            self._last_rendered_stream_version = stream_version
+        finally:
+            elapsed_ms = (time.monotonic() - started) * 1000.0
+            self._last_render_monotonic = time.monotonic()
+            self._render_in_flight = False
+            self._perf_stats["full_redraw_count"] += 1
+            self._perf_stats["redraw_durations_ms"].append(elapsed_ms)
+            if len(self._perf_stats["redraw_durations_ms"]) > 120:
+                self._perf_stats["redraw_durations_ms"] = self._perf_stats["redraw_durations_ms"][-120:]
+        if self._chart_dirty or self._last_rendered_stream_version != self._latest_stream_version:
+            self._request_live_render(immediate=False)
 
     def _widget_pos_to_data(self, pointf):
         if pointf is None:
@@ -2272,7 +2527,8 @@ class LapTimeChartWindow(PitWallWindow):
         ax.set_xlim(new_x_lo, new_x_hi)
         ax.set_ylim(new_y_lo, new_y_hi)
         self._set_user_view((new_x_lo, new_x_hi), (new_y_lo, new_y_hi))
-        self._rebuild_hover_screen_cache()
+        self._overlay_reset()
+        self._invalidate_hover_screen_cache()
         self._canvas.draw_idle()
 
     def _on_button_press(self, event):
@@ -2298,6 +2554,8 @@ class LapTimeChartWindow(PitWallWindow):
             self._pan_active = False
             self._last_pan_draw_ts = 0.0
             self._canvas.unsetCursor()
+            if self._hover_cache_dirty:
+                self._view_refresh_timer.start(30)
 
     def _on_pick(self, event):
         """Toggle isolation when clicking a driver's legend."""
@@ -2333,7 +2591,7 @@ class LapTimeChartWindow(PitWallWindow):
             self._driver_combo.blockSignals(False)
             
             self._needs_full_redraw = True
-            self._redraw()
+            self._redraw_now()
             QTimer.singleShot(0, self._refresh_hover_from_cursor)
 
     def eventFilter(self, obj, event):
@@ -2408,7 +2666,7 @@ class LapTimeChartWindow(PitWallWindow):
         if key == Qt.Key.Key_I:
             self._legend_visible = not self._legend_visible
             self._needs_full_redraw = True
-            self._redraw()
+            self._redraw_now()
             event.accept()
             return True
         if self._canvas.hasFocus():

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -61,6 +61,12 @@ class F1RaceReplayWindow(arcade.Window):
         self.paused = False
         self.total_laps = total_laps
         self.has_weather = any("weather" in frame for frame in frames) if frames else False
+
+        # Pre-compute per-driver lap times from the full frame data.
+        # This avoids playback-speed-dependent sampling errors when insight
+        # windows try to derive lap times from the streamed frames.
+        self._precomputed_lap_times = self._compute_lap_times(frames, session)
+        self._precomputed_status_laps = self._compute_status_laps(frames, track_statuses)
         self.visible_hud = visible_hud # If it displays HUD or not (leaderboard, controls, weather, etc)
 
         # Rotation (degrees) to apply to the whole circuit around its centre
@@ -318,7 +324,610 @@ class F1RaceReplayWindow(arcade.Window):
                 "rotation_deg": self.circuit_rotation,
             }
 
+        # Send pre-computed data continuously. It's just a Python dictionary reference 
+        # (O(1) memory overhead in local publish/subscribe) and ensures windows 
+        # opened after the race has finished still receive the data.
+        payload["lap_times"] = self._precomputed_lap_times
+        payload["status_laps"] = self._precomputed_status_laps
+
         self.telemetry_stream.broadcast(payload)
+
+    @staticmethod
+    def _compute_lap_times(frames, session=None):
+        """
+        Scan the full frame array once to build deterministic lap times
+        for every driver.  Returns {code: [{lap, time_s, end_time_s, tyre}, ...]}.
+        """
+        fallback_result = F1RaceReplayWindow._compute_fallback_lap_times_raw(frames)
+        classified_fallback = F1RaceReplayWindow._classify_lap_entries(
+            fallback_result,
+            official_data=False,
+        )
+
+        if session is not None and hasattr(session, 'laps'):
+            try:
+                import pandas as pd
+                import fastf1._api as ffapi
+                import fastf1.utils as ffutils
+                from src.lib.tyres import get_tyre_compound_int
+                result = {}
+                for _, row in session.laps.iterrows():
+                    code = row.get("Driver")
+                    lap_num = row.get("LapNumber")
+                    lap_time_td = row.get("LapTime")
+                    tyre_str = row.get("Compound")
+                    tyre_life = row.get("TyreLife")
+                    
+                    if pd.isna(lap_num):
+                        continue
+                        
+                    lap = int(lap_num)
+                    time_s = lap_time_td.total_seconds() if pd.notna(lap_time_td) else -1.0
+                    lap_end_td = row.get("Time")
+                    end_time_s = lap_end_td.total_seconds() if pd.notna(lap_end_td) else None
+                    line_end_td = row.get("Sector3SessionTime")
+                    line_end_s = line_end_td.total_seconds() if pd.notna(line_end_td) else end_time_s
+                    
+                    tyre_int = -1
+                    if pd.notna(tyre_str):
+                        tyre_int = get_tyre_compound_int(tyre_str)
+                        
+                    t_life = 0
+                    if pd.notna(tyre_life):
+                        t_life = int(tyre_life)
+                        
+                    is_pit = False
+                    if "PitInTime" in session.laps.columns and pd.notna(row.get("PitInTime")):
+                        is_pit = True
+                        
+                    result.setdefault(code, []).append({
+                        "lap": int(lap_num),
+                        "time_s": float(time_s),
+                        "end_time_s": float(end_time_s) if end_time_s is not None else None,
+                        "line_time_s": float(line_end_s) if line_end_s is not None else None,
+                        "tyre": tyre_int,
+                        "tyre_life": t_life,
+                        "is_pit": is_pit,
+                    })
+                if result:
+                    fallback_by_code = {
+                        code: {entry["lap"]: entry for entry in entries}
+                        for code, entries in classified_fallback.items()
+                    }
+                    for code, entries in result.items():
+                        fallback_entries = fallback_by_code.get(code, {})
+                        for entry in entries:
+                            fb_entry = fallback_entries.get(entry["lap"])
+                            if fb_entry is None:
+                                continue
+                            if entry.get("time_s", -1.0) <= 0 and fb_entry.get("time_s", -1.0) > 0:
+                                entry["time_s"] = fb_entry["time_s"]
+                                entry["time_source"] = "frame_backfill"
+                                entry["source"] = "derived"
+                                if entry.get("end_time_s") is None and fb_entry.get("end_time_s") is not None:
+                                    entry["end_time_s"] = fb_entry["end_time_s"]
+                                if entry.get("line_time_s") is None and fb_entry.get("end_time_s") is not None:
+                                    entry["line_time_s"] = fb_entry["end_time_s"]
+                                if fb_entry.get("start_time_s") is not None:
+                                    entry["start_time_s"] = fb_entry["start_time_s"]
+                            if fb_entry.get("is_pit") and not entry.get("is_pit"):
+                                entry["is_pit"] = True
+                                entry["pit_confidence"] = fb_entry.get("pit_confidence", "medium")
+                            if fb_entry.get("is_out_lap"):
+                                entry["is_out_lap"] = True
+                            if fb_entry.get("is_outlier"):
+                                entry["is_outlier"] = True
+                            if fb_entry.get("pace_baseline_s") is not None and entry.get("pace_baseline_s") is None:
+                                entry["pace_baseline_s"] = fb_entry["pace_baseline_s"]
+                    try:
+                        _, stream_data, _ = ffapi._extended_timing_data(session.api_path)
+                        number_to_code = {}
+                        code_to_number = {}
+                        if (
+                            hasattr(session, "results")
+                            and session.results is not None
+                            and not session.results.empty
+                            and "DriverNumber" in session.results.columns
+                            and "Abbreviation" in session.results.columns
+                        ):
+                            for _, res_row in session.results.iterrows():
+                                drv_num = res_row.get("DriverNumber")
+                                code = res_row.get("Abbreviation")
+                                if pd.notna(drv_num) and pd.notna(code):
+                                    drv_num = str(drv_num)
+                                    code = str(code)
+                                    number_to_code[drv_num] = code
+                                    code_to_number[code] = drv_num
+                        if (
+                            "DriverNumber" in session.laps.columns
+                            and "Driver" in session.laps.columns
+                        ):
+                            for _, lap_row in (
+                                session.laps[["DriverNumber", "Driver"]]
+                                .dropna()
+                                .drop_duplicates()
+                                .iterrows()
+                            ):
+                                drv_num = str(lap_row["DriverNumber"])
+                                code = str(lap_row["Driver"])
+                                number_to_code.setdefault(drv_num, code)
+                                code_to_number.setdefault(code, drv_num)
+
+                        official_pos_lookup = {}
+                        if (
+                            "Driver" in session.laps.columns
+                            and "LapNumber" in session.laps.columns
+                            and "Position" in session.laps.columns
+                        ):
+                            for _, sess_lap_row in session.laps[["Driver", "LapNumber", "Position"]].dropna(subset=["Driver", "LapNumber"]).iterrows():
+                                try:
+                                    pos_val = sess_lap_row.get("Position")
+                                    pos_int = int(pos_val) if pd.notna(pos_val) else None
+                                    official_pos_lookup[(str(sess_lap_row["Driver"]), int(sess_lap_row["LapNumber"]))] = pos_int
+                                except Exception:
+                                    continue
+
+                        def _parse_gap_to_leader(raw_value, row_position):
+                            if pd.isna(raw_value):
+                                return 0.0 if str(row_position or "") == "1" else None
+                            gap_text = str(raw_value).strip()
+                            if not gap_text:
+                                return 0.0 if str(row_position or "") == "1" else None
+                            upper_text = gap_text.upper()
+                            if upper_text.startswith("LAP") or upper_text.endswith(" L") or upper_text.endswith("L"):
+                                return 0.0 if str(row_position or "") == "1" else None
+                            gap_td = ffutils.to_timedelta(gap_text)
+                            if gap_td is not None:
+                                return float(gap_td.total_seconds())
+                            return None
+
+                        def _parse_interval_to_ahead(raw_value):
+                            if pd.isna(raw_value):
+                                return None
+                            gap_text = str(raw_value).strip()
+                            if not gap_text:
+                                return None
+                            upper_text = gap_text.upper()
+                            if upper_text.startswith("LAP") or upper_text.endswith(" L") or upper_text.endswith("L"):
+                                return None
+                            gap_td = ffutils.to_timedelta(gap_text)
+                            if gap_td is not None:
+                                return float(gap_td.total_seconds())
+                            return None
+
+                        lap_match_data = {}
+                        for code, entries in result.items():
+                            drv_num = code_to_number.get(code)
+                            if not drv_num:
+                                continue
+                            drv_stream_rows = stream_data[stream_data["Driver"].astype(str) == drv_num]
+                            if drv_stream_rows.empty:
+                                continue
+                            for lap_entry in entries:
+                                lap_no = lap_entry.get("lap")
+                                gap_s = None
+                                target_time_s = lap_entry.get("line_time_s")
+                                if target_time_s is None:
+                                    target_time_s = lap_entry.get("end_time_s")
+                                if target_time_s is None:
+                                    continue
+                                first_time = pd.to_timedelta(float(target_time_s), unit="s")
+                                official_pos = official_pos_lookup.get((code, lap_no))
+                                time_delta = (drv_stream_rows["Time"] - first_time).abs()
+                                local_window = drv_stream_rows[time_delta <= pd.to_timedelta(20, unit="s")]
+                                matched_stream_row = None
+                                if official_pos is not None and not local_window.empty:
+                                    pos_rows = local_window[local_window["Position"] == official_pos]
+                                    if not pos_rows.empty:
+                                        ref_idx = (pos_rows["Time"] - first_time).abs().idxmin()
+                                        matched_stream_row = pos_rows.loc[ref_idx]
+                                if matched_stream_row is None and not local_window.empty:
+                                    ref_idx = (local_window["Time"] - first_time).abs().idxmin()
+                                    matched_stream_row = local_window.loc[ref_idx]
+                                if matched_stream_row is None:
+                                    candidate_rows = drv_stream_rows[drv_stream_rows["Time"] <= first_time]
+                                    if official_pos is not None and not candidate_rows.empty:
+                                        pos_rows = candidate_rows[candidate_rows["Position"] == official_pos]
+                                        if not pos_rows.empty:
+                                            ref_idx = (pos_rows["Time"] - first_time).abs().idxmin()
+                                            matched_stream_row = pos_rows.loc[ref_idx]
+                                    if matched_stream_row is None and not candidate_rows.empty:
+                                        matched_stream_row = candidate_rows.sort_values("Time").iloc[-1]
+                                if matched_stream_row is None:
+                                    ref_idx = (drv_stream_rows["Time"] - first_time).abs().idxmin()
+                                    matched_stream_row = drv_stream_rows.loc[ref_idx]
+                                matched_position = matched_stream_row.get("Position")
+
+                                interval_chain_reliable = False
+                                interval_quality_rows = local_window
+                                target_position = official_pos
+                                if target_position is None and pd.notna(matched_position):
+                                    try:
+                                        target_position = int(matched_position)
+                                    except Exception:
+                                        target_position = None
+                                if target_position is not None and not interval_quality_rows.empty:
+                                    interval_quality_rows = interval_quality_rows[
+                                        interval_quality_rows["Position"] == target_position
+                                    ]
+                                if not interval_quality_rows.empty:
+                                    scored_intervals = []
+                                    for _, cand_row in interval_quality_rows.iterrows():
+                                        cand_interval_s = _parse_interval_to_ahead(
+                                            cand_row.get("IntervalToPositionAhead")
+                                        )
+                                        if cand_interval_s is None:
+                                            continue
+                                        cand_dt_s = abs(
+                                            float((cand_row["Time"] - first_time).total_seconds())
+                                        )
+                                        scored_intervals.append((cand_dt_s, float(cand_interval_s)))
+                                    if scored_intervals:
+                                        scored_intervals.sort(key=lambda item: item[0])
+                                        close_intervals = [
+                                            val for dt_s, val in scored_intervals[:4] if dt_s <= 6.0
+                                        ]
+                                        if len(close_intervals) >= 2:
+                                            interval_chain_reliable = (
+                                                max(close_intervals) - min(close_intervals) <= 1.0
+                                            )
+                                gap_s = _parse_gap_to_leader(
+                                    matched_stream_row.get("GapToLeader"), matched_position
+                                )
+                                interval_s = _parse_interval_to_ahead(
+                                    matched_stream_row.get("IntervalToPositionAhead")
+                                )
+                                if gap_s is None and interval_s is None:
+                                    continue
+
+                                if matched_stream_row.get("Time") is not None and pd.notna(matched_stream_row.get("Time")):
+                                    lap_entry["official_stream_time_s"] = float(
+                                        matched_stream_row["Time"].total_seconds()
+                                    )
+                                if pd.notna(matched_position):
+                                    try:
+                                        lap_entry["official_stream_position"] = int(matched_position)
+                                    except Exception:
+                                        pass
+                                if interval_s is not None:
+                                    lap_entry["official_interval_to_ahead_s"] = float(interval_s)
+
+                                lap_match_data.setdefault(int(lap_no), []).append(
+                                    {
+                                        "code": code,
+                                        "entry": lap_entry,
+                                        "official_pos": official_pos,
+                                        "matched_pos": (
+                                            int(matched_position)
+                                            if pd.notna(matched_position)
+                                            else None
+                                        ),
+                                        "gap_s": gap_s,
+                                        "interval_s": interval_s,
+                                        "interval_chain_reliable": interval_chain_reliable,
+                                    }
+                                )
+
+                        # Reconstruct a coherent per-lap official gap ladder. Direct GapToLeader
+                        # remains authoritative when present. IntervalToPositionAhead is only used
+                        # to fill gaps where GapToLeader is absent/non-numeric.
+                        for _, lap_items in lap_match_data.items():
+                            ordered_items = sorted(
+                                lap_items,
+                                key=lambda item: (
+                                    item["official_pos"] is None,
+                                    item["official_pos"]
+                                    if item["official_pos"] is not None
+                                    else (
+                                        item["matched_pos"]
+                                        if item["matched_pos"] is not None
+                                        else 999
+                                    ),
+                                    item["code"],
+                                ),
+                            )
+                            assigned_by_pos = {}
+                            for item in ordered_items:
+                                pos = item["official_pos"]
+                                if pos is None:
+                                    pos = item["matched_pos"]
+                                if pos is None:
+                                    continue
+
+                                direct_gap_s = item["gap_s"]
+                                if pos == 1:
+                                    assigned_gap_s = 0.0
+                                    source = "direct"
+                                else:
+                                    prev_gap_s = assigned_by_pos.get(pos - 1)
+                                    predicted_gap_s = None
+                                    if (
+                                        prev_gap_s is not None
+                                        and item["interval_s"] is not None
+                                        and item.get("interval_chain_reliable")
+                                    ):
+                                        predicted_gap_s = float(prev_gap_s) + float(item["interval_s"])
+
+                                    assigned_gap_s = None
+                                    source = None
+                                    if direct_gap_s is not None:
+                                        assigned_gap_s = float(direct_gap_s)
+                                        source = "direct"
+                                    elif predicted_gap_s is not None:
+                                        assigned_gap_s = float(predicted_gap_s)
+                                        source = "interval_chain"
+
+                                if assigned_gap_s is None:
+                                    continue
+                                assigned_by_pos[pos] = assigned_gap_s
+                                item["entry"]["official_gap_to_leader_s"] = float(assigned_gap_s)
+                                item["entry"]["official_gap_source"] = source
+                    except Exception:
+                        pass
+                    try:
+                        import pandas as pd
+                        results_df = session.results
+                        if results_df is not None and not results_df.empty:
+                            winner_rows = results_df[results_df["ClassifiedPosition"] == "1"]
+                            if not winner_rows.empty:
+                                winner_row = winner_rows.iloc[0]
+                                winner_code = winner_row.get("Abbreviation")
+                                winner_laps = int(winner_row.get("Laps", 0) or 0)
+                                if winner_code in result and winner_laps > 0:
+                                    winner_entries = {e["lap"]: e for e in result[winner_code]}
+                                    winner_entry = winner_entries.get(winner_laps)
+                                    if winner_entry is not None:
+                                        winner_entry["official_finish_gap_s"] = 0.0
+
+                                for _, res_row in results_df.iterrows():
+                                    code = res_row.get("Abbreviation")
+                                    if code not in result:
+                                        continue
+                                    if str(res_row.get("Status", "")) != "Finished":
+                                        continue
+                                    laps_done = int(res_row.get("Laps", 0) or 0)
+                                    if winner_laps <= 0 or laps_done != winner_laps:
+                                        continue
+                                    gap_td = res_row.get("Time")
+                                    if code == winner_code:
+                                        gap_s = 0.0
+                                    elif pd.isna(gap_td):
+                                        continue
+                                    else:
+                                        gap_s = float(gap_td.total_seconds())
+                                    lap_entry = next((e for e in result[code] if e["lap"] == winner_laps), None)
+                                    if lap_entry is not None:
+                                        lap_entry["official_finish_gap_s"] = gap_s
+
+                            for _, res_row in results_df.iterrows():
+                                code = str(res_row.get("Abbreviation", "")).strip()
+                                if not code:
+                                    continue
+                                laps_completed = res_row.get("Laps")
+                                if pd.isna(laps_completed):
+                                    continue
+                                try:
+                                    terminal_lap = int(laps_completed)
+                                except (TypeError, ValueError):
+                                    continue
+
+                                status_text = str(res_row.get("Status", "")).strip()
+                                classified_pos = str(res_row.get("ClassifiedPosition", "")).strip()
+                                is_terminal_retirement = (
+                                    classified_pos == "R"
+                                    or (
+                                        status_text
+                                        and status_text not in {"Finished", "Lapped"}
+                                        and not status_text.startswith("+")
+                                    )
+                                )
+                                if not is_terminal_retirement:
+                                    continue
+
+                                code_entries = result.setdefault(code, [])
+                                terminal_entry = next(
+                                    (e for e in code_entries if e.get("lap") == terminal_lap),
+                                    None,
+                                )
+                                if terminal_entry is None:
+                                    terminal_entry = {
+                                        "lap": terminal_lap,
+                                        "time_s": -1.0,
+                                        "end_time_s": None,
+                                        "line_time_s": None,
+                                        "tyre": -1,
+                                        "tyre_life": 0,
+                                        "is_pit": False,
+                                        "source": "official",
+                                    }
+                                    code_entries.append(terminal_entry)
+
+                                terminal_entry["is_terminal_lap"] = True
+                                terminal_entry["result_status"] = status_text or "Retired"
+                    except Exception:
+                        pass
+                    return F1RaceReplayWindow._classify_lap_entries(result, official_data=True)
+            except Exception as e:
+                print(f"Error parsing official lap times: {e}")
+
+        return classified_fallback
+
+    @staticmethod
+    def _compute_fallback_lap_times_raw(frames, min_lap_time_s=30.0, max_lap_time_s=7200.0):
+        lap_start_t = {}    # code -> session time when current lap began
+        current_lap = {}    # code -> last seen lap number
+        result = {}         # code -> list of lap time entries
+
+        for frame in frames:
+            t = frame.get("t", 0)
+            drivers = frame.get("drivers", {})
+            for code, drv in drivers.items():
+                lap = drv.get("lap")
+                if lap is None:
+                    continue
+
+                prev_lap = current_lap.get(code)
+                if prev_lap is None:
+                    current_lap[code] = lap
+                    lap_start_t[code] = t
+                    result.setdefault(code, [])
+                    continue
+
+                if lap > prev_lap:
+                    lap_time = t - lap_start_t.get(code, t)
+                    tyre = int(round(drv.get("tyre", 0)))
+                    tyre_life = int(round(drv.get("tyre_life", 0)))
+
+                    if min_lap_time_s < lap_time < max_lap_time_s and prev_lap >= 2:
+                        result.setdefault(code, []).append({
+                            "lap": prev_lap,
+                            "time_s": float(lap_time),
+                            "end_time_s": float(t),
+                            "tyre": tyre,
+                            "tyre_life": tyre_life,
+                            "start_time_s": float(lap_start_t.get(code, t)),
+                        })
+
+                    current_lap[code] = lap
+                    lap_start_t[code] = t
+
+        return result
+
+    @staticmethod
+    def _classify_lap_entries(result, official_data=False):
+        """
+        Enrich lap entries with derived metadata so insight windows can
+        distinguish pit laps, out laps, and generic slow-lap outliers even
+        when official pit timing fields are unavailable.
+        """
+        for entries in result.values():
+            entries.sort(key=lambda e: e["lap"])
+            clean_history = []
+            gap_clock_s = 0.0
+
+            for i, entry in enumerate(entries):
+                next_entry = entries[i + 1] if i + 1 < len(entries) else None
+                entry.setdefault("source", "official" if official_data else "derived")
+                entry.setdefault("is_pit", False)
+                entry.setdefault("is_out_lap", False)
+                entry.setdefault("is_outlier", False)
+                entry.setdefault(
+                    "pit_confidence",
+                    "official" if entry.get("is_pit") and entry.get("source") == "official" else "none",
+                )
+
+                baseline_pool = clean_history[-5:]
+                baseline = None
+                if baseline_pool:
+                    baseline = sorted(baseline_pool)[len(baseline_pool) // 2]
+                    entry["pace_baseline_s"] = round(float(baseline), 3)
+
+                time_s = entry.get("time_s", -1.0)
+                if time_s > 0:
+                    gap_clock_s += float(time_s)
+                    entry["gap_clock_s"] = gap_clock_s
+                else:
+                    entry["gap_clock_s"] = None
+                if (
+                    entry.get("source") != "official"
+                    and not entry.get("is_pit")
+                    and baseline is not None
+                    and time_s > 0
+                    and entry["lap"] > 1
+                ):
+                    tyre = entry.get("tyre", -1)
+                    tyre_life = entry.get("tyre_life", -1)
+                    next_tyre = next_entry.get("tyre", -1) if next_entry else -1
+                    next_tyre_life = next_entry.get("tyre_life", -1) if next_entry else -1
+
+                    compound_change = (
+                        next_entry is not None
+                        and tyre != -1
+                        and next_tyre != -1
+                        and next_tyre != tyre
+                    )
+                    age_reset = (
+                        next_entry is not None
+                        and tyre_life >= 0
+                        and next_tyre_life >= 0
+                        and next_tyre_life <= 2
+                        and next_tyre_life + 1 < tyre_life
+                    )
+                    severe_delta = (time_s - baseline) >= max(12.0, baseline * 0.12)
+                    moderate_delta = (time_s - baseline) >= max(7.0, baseline * 0.08)
+
+                    if severe_delta and (compound_change or age_reset):
+                        entry["is_pit"] = True
+                        entry["pit_confidence"] = "high"
+                    elif moderate_delta and age_reset:
+                        entry["is_pit"] = True
+                        entry["pit_confidence"] = "medium"
+                    elif severe_delta:
+                        entry["is_outlier"] = True
+
+                if entry.get("is_pit") and next_entry and next_entry["lap"] == entry["lap"] + 1:
+                    next_entry["is_out_lap"] = True
+
+                if (
+                    time_s > 0
+                    and not entry.get("is_pit")
+                    and not entry.get("is_out_lap")
+                    and not entry.get("is_outlier")
+                ):
+                    clean_history.append(time_s)
+
+        return result
+
+    @staticmethod
+    def _compute_status_laps(frames, track_statuses):
+        """
+        Map track status periods to leader lap numbers.
+        Returns a list of {"status": str, "start_lap": int, "end_lap": int}.
+
+        Status codes: "4" = Safety Car, "6" = VSC, "7" = VSC Ending,
+                      "5" = Red Flag.
+        """
+        if not track_statuses or not frames:
+            return []
+
+        # Build a time → leader lap lookup from frames
+        # (sample every 25th frame for speed; 1 sample per second is plenty)
+        time_to_lap = []
+        for i in range(0, len(frames), 25):
+            f = frames[i]
+            t = f.get("t", 0)
+            lap = f.get("lap", 1)
+            time_to_lap.append((t, int(lap)))
+
+        def _lap_at_time(target_t):
+            """Binary-ish lookup for leader lap at a given session time."""
+            best_lap = 1
+            for t, lap in time_to_lap:
+                if t <= target_t:
+                    best_lap = lap
+                else:
+                    break
+            return best_lap
+
+        result = []
+        for status in track_statuses:
+            code = str(status.get("status", ""))
+            if code not in ("4", "5", "6", "7"):
+                continue
+            start_t = status.get("start_time", 0)
+            end_t = status.get("end_time")
+            start_lap = _lap_at_time(start_t)
+            end_lap = _lap_at_time(end_t) if end_t else start_lap
+            # Merge consecutive entries with same status
+            if result and result[-1]["status"] == code and result[-1]["end_lap"] >= start_lap - 1:
+                result[-1]["end_lap"] = max(result[-1]["end_lap"], end_lap)
+            else:
+                result.append({
+                    "status": code,
+                    "start_lap": start_lap,
+                    "end_lap": end_lap,
+                })
+        return result
 
     def _interpolate_points(self, xs, ys, interp_points=2000):
         t_old = np.linspace(0, 1, len(xs))

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -306,6 +306,7 @@ class F1RaceReplayWindow(arcade.Window):
             "race_control_events": rc_events,
             "session_data": {
                 "time": time_str,
+                "time_s": float(t),
                 "lap": leader_lap,
                 "leader": leader_code,
                 "total_laps": self.total_laps
@@ -393,6 +394,8 @@ class F1RaceReplayWindow(arcade.Window):
                         "is_pit_entry": is_pit_entry,
                         "is_pit_affected": is_pit_entry,
                         "is_out_lap": is_out_lap,
+                        "fastf1_generated": bool(row.get("FastF1Generated", False)),
+                        "is_accurate": bool(row.get("IsAccurate", True)),
                     })
                 if result:
                     fallback_by_code = {
@@ -425,6 +428,16 @@ class F1RaceReplayWindow(arcade.Window):
                                 entry["is_outlier"] = True
                             if fb_entry.get("pace_baseline_s") is not None and entry.get("pace_baseline_s") is None:
                                 entry["pace_baseline_s"] = fb_entry["pace_baseline_s"]
+
+                    F1RaceReplayWindow._fill_missing_official_tyre_life(result)
+                    replay_time_offset_s = F1RaceReplayWindow._estimate_official_replay_time_offset(
+                        result,
+                        classified_fallback,
+                    )
+                    F1RaceReplayWindow._attach_replay_aligned_lap_times(
+                        result,
+                        replay_time_offset_s,
+                    )
                     try:
                         _, stream_data, _ = ffapi._extended_timing_data(session.api_path)
                         required_stream_cols = {"Driver", "Time", "Position", "GapToLeader", "IntervalToPositionAhead"}
@@ -724,10 +737,46 @@ class F1RaceReplayWindow(arcade.Window):
                                     continue
 
                                 code_entries = result.setdefault(code, [])
-                                terminal_entry = next(
+                                completed_entry = next(
                                     (e for e in code_entries if e.get("lap") == terminal_lap),
                                     None,
                                 )
+                                terminal_entry = next(
+                                    (
+                                        e for e in code_entries
+                                        if e.get("lap") == terminal_lap + 1
+                                        and (
+                                            e.get("time_s", -1.0) <= 0
+                                            or e.get("fastf1_generated")
+                                            or not e.get("is_accurate", True)
+                                        )
+                                    ),
+                                    None,
+                                )
+                                if (
+                                    terminal_entry is not None
+                                    and completed_entry is not None
+                                ):
+                                    completed_time_s = (
+                                        completed_entry.get("line_time_s")
+                                        if completed_entry.get("line_time_s") is not None
+                                        else completed_entry.get("end_time_s")
+                                    )
+                                    terminal_time_s = (
+                                        terminal_entry.get("line_time_s")
+                                        if terminal_entry.get("line_time_s") is not None
+                                        else terminal_entry.get("end_time_s")
+                                    )
+                                    if (
+                                        terminal_time_s is None
+                                        or completed_time_s is None
+                                        or terminal_time_s <= completed_time_s
+                                    ):
+                                        terminal_entry = None
+
+                                if terminal_entry is None:
+                                    terminal_entry = completed_entry
+
                                 if terminal_entry is None:
                                     terminal_entry = {
                                         "lap": terminal_lap,
@@ -742,6 +791,19 @@ class F1RaceReplayWindow(arcade.Window):
                                     code_entries.append(terminal_entry)
 
                                 terminal_entry["is_terminal_lap"] = True
+                                terminal_event_time_s = (
+                                    terminal_entry.get("replay_line_time_s")
+                                    if terminal_entry.get("replay_line_time_s") is not None
+                                    else terminal_entry.get("replay_end_time_s")
+                                )
+                                if terminal_event_time_s is None:
+                                    terminal_event_time_s = (
+                                        terminal_entry.get("line_time_s")
+                                        if terminal_entry.get("line_time_s") is not None
+                                        else terminal_entry.get("end_time_s")
+                                    )
+                                if terminal_event_time_s is not None:
+                                    terminal_entry["terminal_event_time_s"] = terminal_event_time_s
                                 if classified_pos == "R":
                                     terminal_entry["result_status"] = "Retired"
                                 else:
@@ -753,6 +815,110 @@ class F1RaceReplayWindow(arcade.Window):
                 print(f"Error parsing official lap times: {e}")
 
         return classified_fallback
+
+    @staticmethod
+    def _estimate_official_replay_time_offset(official_result, fallback_result):
+        diffs = []
+        for code, entries in official_result.items():
+            fallback_entries = {
+                entry.get("lap"): entry
+                for entry in fallback_result.get(code, [])
+                if isinstance(entry.get("end_time_s"), (int, float))
+            }
+            for entry in entries:
+                if entry.get("time_source") == "frame_backfill":
+                    continue
+                lap = entry.get("lap")
+                fb_entry = fallback_entries.get(lap)
+                line_time_s = entry.get("line_time_s")
+                if (
+                    fb_entry is None
+                    or not isinstance(line_time_s, (int, float))
+                ):
+                    continue
+                diff = float(line_time_s) - float(fb_entry["end_time_s"])
+                if 0.0 <= diff <= 8 * 3600:
+                    diffs.append(diff)
+        if len(diffs) < 5:
+            return None
+        diffs.sort()
+        return float(diffs[len(diffs) // 2])
+
+    @staticmethod
+    def _attach_replay_aligned_lap_times(result, replay_time_offset_s):
+        if replay_time_offset_s is None:
+            return
+        for entries in result.values():
+            for entry in entries:
+                for src_key, dst_key in (
+                    ("line_time_s", "replay_line_time_s"),
+                    ("end_time_s", "replay_end_time_s"),
+                ):
+                    src_val = entry.get(src_key)
+                    if not isinstance(src_val, (int, float)):
+                        continue
+                    if entry.get("time_source") == "frame_backfill":
+                        entry[dst_key] = float(src_val)
+                    else:
+                        aligned_val = float(src_val) - replay_time_offset_s
+                        if aligned_val >= 0:
+                            entry[dst_key] = aligned_val
+
+    @staticmethod
+    def _fill_missing_official_tyre_life(result):
+        def _iter_stints(entries):
+            current = []
+            prev = None
+            for entry in entries:
+                tyre = entry.get("tyre", -1)
+                if tyre == -1:
+                    if current:
+                        yield current
+                        current = []
+                    prev = entry
+                    continue
+                new_stint = (
+                    not current
+                    or prev is None
+                    or entry.get("lap") != prev.get("lap", 0) + 1
+                    or entry.get("tyre") != prev.get("tyre")
+                    or entry.get("is_out_lap")
+                    or prev.get("is_pit_entry")
+                )
+                if new_stint:
+                    if current:
+                        yield current
+                    current = [entry]
+                else:
+                    current.append(entry)
+                prev = entry
+            if current:
+                yield current
+
+        for entries in result.values():
+            entries.sort(key=lambda item: item.get("lap", 0))
+            for stint in _iter_stints(entries):
+                known = [
+                    (int(entry["lap"]), int(entry["tyre_life"]))
+                    for entry in stint
+                    if isinstance(entry.get("tyre_life"), (int, float))
+                    and int(entry.get("tyre_life", 0)) > 0
+                ]
+                if known:
+                    anchor_lap, anchor_life = known[0]
+                    for entry in stint:
+                        if int(entry.get("tyre_life", 0)) > 0:
+                            continue
+                        inferred = anchor_life + (int(entry["lap"]) - anchor_lap)
+                        if inferred > 0:
+                            entry["tyre_life"] = inferred
+                    continue
+
+                first_entry = stint[0]
+                if first_entry.get("is_out_lap") or int(first_entry.get("lap", 0)) == 1:
+                    for idx, entry in enumerate(stint, start=1):
+                        if int(entry.get("tyre_life", 0)) <= 0:
+                            entry["tyre_life"] = idx
 
     @staticmethod
     def _compute_fallback_lap_times_raw(frames, min_lap_time_s=30.0, max_lap_time_s=7200.0):

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -479,29 +479,16 @@ class F1RaceReplayWindow(arcade.Window):
                                 except (TypeError, ValueError):
                                     continue
 
-                        def _parse_gap_to_leader(raw_value, row_position):
+                        def _parse_timing_delta(raw_value, row_position=None):
+                            leader_row = str(row_position or "") == "1"
                             if pd.isna(raw_value):
-                                return 0.0 if str(row_position or "") == "1" else None
+                                return 0.0 if leader_row else None
                             gap_text = str(raw_value).strip()
                             if not gap_text:
-                                return 0.0 if str(row_position or "") == "1" else None
+                                return 0.0 if leader_row else None
                             upper_text = gap_text.upper()
                             if upper_text.startswith("LAP") or upper_text.endswith(" L") or upper_text.endswith("L"):
-                                return 0.0 if str(row_position or "") == "1" else None
-                            gap_td = ffutils.to_timedelta(gap_text)
-                            if gap_td is not None:
-                                return float(gap_td.total_seconds())
-                            return None
-
-                        def _parse_interval_to_ahead(raw_value):
-                            if pd.isna(raw_value):
-                                return None
-                            gap_text = str(raw_value).strip()
-                            if not gap_text:
-                                return None
-                            upper_text = gap_text.upper()
-                            if upper_text.startswith("LAP") or upper_text.endswith(" L") or upper_text.endswith("L"):
-                                return None
+                                return 0.0 if leader_row else None
                             gap_td = ffutils.to_timedelta(gap_text)
                             if gap_td is not None:
                                 return float(gap_td.total_seconds())
@@ -565,7 +552,7 @@ class F1RaceReplayWindow(arcade.Window):
                                 if not interval_quality_rows.empty:
                                     scored_intervals = []
                                     for _, cand_row in interval_quality_rows.iterrows():
-                                        cand_interval_s = _parse_interval_to_ahead(
+                                        cand_interval_s = _parse_timing_delta(
                                             cand_row.get("IntervalToPositionAhead")
                                         )
                                         if cand_interval_s is None:
@@ -583,10 +570,10 @@ class F1RaceReplayWindow(arcade.Window):
                                             interval_chain_reliable = (
                                                 max(close_intervals) - min(close_intervals) <= 1.0
                                             )
-                                gap_s = _parse_gap_to_leader(
+                                gap_s = _parse_timing_delta(
                                     matched_stream_row.get("GapToLeader"), matched_position
                                 )
-                                interval_s = _parse_interval_to_ahead(
+                                interval_s = _parse_timing_delta(
                                     matched_stream_row.get("IntervalToPositionAhead")
                                 )
                                 if gap_s is None and interval_s is None:
@@ -1508,4 +1495,3 @@ class F1RaceReplayWindow(arcade.Window):
             print("Stopping telemetry stream server...")
             self.telemetry_stream.stop()
         super().close()
-

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -376,9 +376,12 @@ class F1RaceReplayWindow(arcade.Window):
                     if pd.notna(tyre_life):
                         t_life = int(tyre_life)
                         
-                    is_pit = False
+                    is_pit_entry = False
                     if "PitInTime" in session.laps.columns and pd.notna(row.get("PitInTime")):
-                        is_pit = True
+                        is_pit_entry = True
+                    is_out_lap = False
+                    if "PitOutTime" in session.laps.columns and pd.notna(row.get("PitOutTime")):
+                        is_out_lap = True
                         
                     result.setdefault(code, []).append({
                         "lap": int(lap_num),
@@ -387,7 +390,9 @@ class F1RaceReplayWindow(arcade.Window):
                         "line_time_s": float(line_end_s) if line_end_s is not None else None,
                         "tyre": tyre_int,
                         "tyre_life": t_life,
-                        "is_pit": is_pit,
+                        "is_pit_entry": is_pit_entry,
+                        "is_pit_affected": is_pit_entry,
+                        "is_out_lap": is_out_lap,
                     })
                 if result:
                     fallback_by_code = {
@@ -410,9 +415,10 @@ class F1RaceReplayWindow(arcade.Window):
                                     entry["line_time_s"] = fb_entry["end_time_s"]
                                 if fb_entry.get("start_time_s") is not None:
                                     entry["start_time_s"] = fb_entry["start_time_s"]
-                            if fb_entry.get("is_pit") and not entry.get("is_pit"):
-                                entry["is_pit"] = True
-                                entry["pit_confidence"] = fb_entry.get("pit_confidence", "medium")
+                            if (fb_entry.get("is_pit_affected") or fb_entry.get("is_pit")) and not entry.get("is_pit_affected"):
+                                entry["is_pit_affected"] = True
+                                if not entry.get("pit_confidence") or entry.get("pit_confidence") == "none":
+                                    entry["pit_confidence"] = fb_entry.get("pit_confidence", "medium")
                             if fb_entry.get("is_out_lap"):
                                 entry["is_out_lap"] = True
                             if fb_entry.get("is_outlier"):
@@ -421,6 +427,12 @@ class F1RaceReplayWindow(arcade.Window):
                                 entry["pace_baseline_s"] = fb_entry["pace_baseline_s"]
                     try:
                         _, stream_data, _ = ffapi._extended_timing_data(session.api_path)
+                        required_stream_cols = {"Driver", "Time", "Position", "GapToLeader", "IntervalToPositionAhead"}
+                        missing_stream_cols = required_stream_cols.difference(stream_data.columns)
+                        if missing_stream_cols:
+                            raise KeyError(
+                                f"extended timing data missing columns: {sorted(missing_stream_cols)}"
+                            )
                         number_to_code = {}
                         code_to_number = {}
                         if (
@@ -464,7 +476,7 @@ class F1RaceReplayWindow(arcade.Window):
                                     pos_val = sess_lap_row.get("Position")
                                     pos_int = int(pos_val) if pd.notna(pos_val) else None
                                     official_pos_lookup[(str(sess_lap_row["Driver"]), int(sess_lap_row["LapNumber"]))] = pos_int
-                                except Exception:
+                                except (TypeError, ValueError):
                                     continue
 
                         def _parse_gap_to_leader(raw_value, row_position):
@@ -544,7 +556,7 @@ class F1RaceReplayWindow(arcade.Window):
                                 if target_position is None and pd.notna(matched_position):
                                     try:
                                         target_position = int(matched_position)
-                                    except Exception:
+                                    except (TypeError, ValueError):
                                         target_position = None
                                 if target_position is not None and not interval_quality_rows.empty:
                                     interval_quality_rows = interval_quality_rows[
@@ -587,7 +599,7 @@ class F1RaceReplayWindow(arcade.Window):
                                 if pd.notna(matched_position):
                                     try:
                                         lap_entry["official_stream_position"] = int(matched_position)
-                                    except Exception:
+                                    except (TypeError, ValueError):
                                         pass
                                 if interval_s is not None:
                                     lap_entry["official_interval_to_ahead_s"] = float(interval_s)
@@ -662,8 +674,8 @@ class F1RaceReplayWindow(arcade.Window):
                                 assigned_by_pos[pos] = assigned_gap_s
                                 item["entry"]["official_gap_to_leader_s"] = float(assigned_gap_s)
                                 item["entry"]["official_gap_source"] = source
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        print(f"Warning: official gap enrichment failed, using fallback gaps where needed: {e}")
                     try:
                         import pandas as pd
                         results_df = session.results
@@ -743,9 +755,12 @@ class F1RaceReplayWindow(arcade.Window):
                                     code_entries.append(terminal_entry)
 
                                 terminal_entry["is_terminal_lap"] = True
-                                terminal_entry["result_status"] = status_text or "Retired"
-                    except Exception:
-                        pass
+                                if classified_pos == "R":
+                                    terminal_entry["result_status"] = "Retired"
+                                else:
+                                    terminal_entry["result_status"] = status_text or "Retired"
+                    except Exception as e:
+                        print(f"Warning: result-status enrichment failed, continuing without terminal/result metadata: {e}")
                     return F1RaceReplayWindow._classify_lap_entries(result, official_data=True)
             except Exception as e:
                 print(f"Error parsing official lap times: {e}")
@@ -808,12 +823,13 @@ class F1RaceReplayWindow(arcade.Window):
             for i, entry in enumerate(entries):
                 next_entry = entries[i + 1] if i + 1 < len(entries) else None
                 entry.setdefault("source", "official" if official_data else "derived")
-                entry.setdefault("is_pit", False)
+                entry.setdefault("is_pit_entry", bool(entry.get("is_pit", False)))
+                entry.setdefault("is_pit_affected", bool(entry.get("is_pit_entry", False) or entry.get("is_pit", False)))
                 entry.setdefault("is_out_lap", False)
                 entry.setdefault("is_outlier", False)
                 entry.setdefault(
                     "pit_confidence",
-                    "official" if entry.get("is_pit") and entry.get("source") == "official" else "none",
+                    "official" if entry.get("is_pit_entry") and entry.get("source") == "official" else "none",
                 )
 
                 baseline_pool = clean_history[-5:]
@@ -830,7 +846,7 @@ class F1RaceReplayWindow(arcade.Window):
                     entry["gap_clock_s"] = None
                 if (
                     entry.get("source") != "official"
-                    and not entry.get("is_pit")
+                    and not entry.get("is_pit_affected")
                     and baseline is not None
                     and time_s > 0
                     and entry["lap"] > 1
@@ -857,20 +873,22 @@ class F1RaceReplayWindow(arcade.Window):
                     moderate_delta = (time_s - baseline) >= max(7.0, baseline * 0.08)
 
                     if severe_delta and (compound_change or age_reset):
-                        entry["is_pit"] = True
+                        entry["is_pit_affected"] = True
                         entry["pit_confidence"] = "high"
                     elif moderate_delta and age_reset:
-                        entry["is_pit"] = True
+                        entry["is_pit_affected"] = True
                         entry["pit_confidence"] = "medium"
                     elif severe_delta:
                         entry["is_outlier"] = True
 
-                if entry.get("is_pit") and next_entry and next_entry["lap"] == entry["lap"] + 1:
+                if entry.get("is_pit_entry") and next_entry and next_entry["lap"] == entry["lap"] + 1:
                     next_entry["is_out_lap"] = True
+
+                entry["is_pit"] = bool(entry.get("is_pit_affected"))
 
                 if (
                     time_s > 0
-                    and not entry.get("is_pit")
+                    and not entry.get("is_pit_affected")
                     and not entry.get("is_out_lap")
                     and not entry.get("is_outlier")
                 ):
@@ -1490,3 +1508,4 @@ class F1RaceReplayWindow(arcade.Window):
             print("Stopping telemetry stream server...")
             self.telemetry_stream.stop()
         super().close()
+

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -416,6 +416,10 @@ class F1RaceReplayWindow(arcade.Window):
                                     entry["end_time_s"] = fb_entry["end_time_s"]
                                 if entry.get("line_time_s") is None and fb_entry.get("end_time_s") is not None:
                                     entry["line_time_s"] = fb_entry["end_time_s"]
+                                if fb_entry.get("end_time_s") is not None:
+                                    replay_end = float(fb_entry["end_time_s"])
+                                    entry["replay_end_time_s"] = replay_end
+                                    entry["replay_line_time_s"] = replay_end
                                 if fb_entry.get("start_time_s") is not None:
                                     entry["start_time_s"] = fb_entry["start_time_s"]
                             if (fb_entry.get("is_pit_affected") or fb_entry.get("is_pit")) and not entry.get("is_pit_affected"):
@@ -437,6 +441,7 @@ class F1RaceReplayWindow(arcade.Window):
                     F1RaceReplayWindow._attach_replay_aligned_lap_times(
                         result,
                         replay_time_offset_s,
+                        classified_fallback,
                     )
                     try:
                         _, stream_data, _ = ffapi._extended_timing_data(session.api_path)
@@ -725,16 +730,17 @@ class F1RaceReplayWindow(arcade.Window):
 
                                 status_text = str(res_row.get("Status", "")).strip()
                                 classified_pos = str(res_row.get("ClassifiedPosition", "")).strip()
-                                is_terminal_retirement = (
-                                    classified_pos == "R"
-                                    or (
-                                        status_text
-                                        and status_text not in {"Finished", "Lapped"}
-                                        and not status_text.startswith("+")
-                                    )
-                                )
-                                if not is_terminal_retirement:
-                                    continue
+
+                                def _is_terminal_event_entry(entry):
+                                    if entry is None:
+                                        return False
+                                    if entry.get("time_s", -1.0) <= 0:
+                                        return True
+                                    if entry.get("fastf1_generated"):
+                                        return True
+                                    if not entry.get("is_accurate", True):
+                                        return True
+                                    return False
 
                                 code_entries = result.setdefault(code, [])
                                 completed_entry = next(
@@ -745,11 +751,7 @@ class F1RaceReplayWindow(arcade.Window):
                                     (
                                         e for e in code_entries
                                         if e.get("lap") == terminal_lap + 1
-                                        and (
-                                            e.get("time_s", -1.0) <= 0
-                                            or e.get("fastf1_generated")
-                                            or not e.get("is_accurate", True)
-                                        )
+                                        and _is_terminal_event_entry(e)
                                     ),
                                     None,
                                 )
@@ -773,6 +775,16 @@ class F1RaceReplayWindow(arcade.Window):
                                         or terminal_time_s <= completed_time_s
                                     ):
                                         terminal_entry = None
+
+                                has_follow_on_terminal_event = terminal_entry is not None
+                                has_same_lap_terminal_event = (
+                                    not has_follow_on_terminal_event
+                                    and _is_terminal_event_entry(completed_entry)
+                                )
+                                if classified_pos != "R":
+                                    continue
+                                if not (has_follow_on_terminal_event or has_same_lap_terminal_event):
+                                    continue
 
                                 if terminal_entry is None:
                                     terminal_entry = completed_entry
@@ -804,10 +816,14 @@ class F1RaceReplayWindow(arcade.Window):
                                     )
                                 if terminal_event_time_s is not None:
                                     terminal_entry["terminal_event_time_s"] = terminal_event_time_s
-                                if classified_pos == "R":
+                                if (
+                                    not status_text
+                                    or status_text in {"Finished", "Lapped"}
+                                    or status_text.startswith("+")
+                                ):
                                     terminal_entry["result_status"] = "Retired"
                                 else:
-                                    terminal_entry["result_status"] = status_text or "Retired"
+                                    terminal_entry["result_status"] = status_text
                     except Exception as e:
                         print(f"Warning: result-status enrichment failed, continuing without terminal/result metadata: {e}")
                     return F1RaceReplayWindow._classify_lap_entries(result, official_data=True)
@@ -845,24 +861,43 @@ class F1RaceReplayWindow(arcade.Window):
         return float(diffs[len(diffs) // 2])
 
     @staticmethod
-    def _attach_replay_aligned_lap_times(result, replay_time_offset_s):
-        if replay_time_offset_s is None:
-            return
-        for entries in result.values():
+    def _attach_replay_aligned_lap_times(result, replay_time_offset_s, fallback_result=None):
+        fallback_by_code = {}
+        if fallback_result:
+            fallback_by_code = {
+                code: {
+                    entry.get("lap"): entry
+                    for entry in entries
+                    if isinstance(entry.get("end_time_s"), (int, float))
+                }
+                for code, entries in fallback_result.items()
+            }
+
+        for code, entries in result.items():
+            fallback_entries = fallback_by_code.get(code, {})
             for entry in entries:
+                if entry.get("time_source") == "frame_backfill":
+                    fb_entry = fallback_entries.get(entry.get("lap"))
+                    if fb_entry is not None and isinstance(fb_entry.get("end_time_s"), (int, float)):
+                        replay_end = float(fb_entry["end_time_s"])
+                        entry.setdefault("replay_line_time_s", replay_end)
+                        entry.setdefault("replay_end_time_s", replay_end)
+
+                if replay_time_offset_s is None:
+                    continue
+
                 for src_key, dst_key in (
                     ("line_time_s", "replay_line_time_s"),
                     ("end_time_s", "replay_end_time_s"),
                 ):
+                    if isinstance(entry.get(dst_key), (int, float)):
+                        continue
                     src_val = entry.get(src_key)
                     if not isinstance(src_val, (int, float)):
                         continue
-                    if entry.get("time_source") == "frame_backfill":
-                        entry[dst_key] = float(src_val)
-                    else:
-                        aligned_val = float(src_val) - replay_time_offset_s
-                        if aligned_val >= 0:
-                            entry[dst_key] = aligned_val
+                    aligned_val = float(src_val) - replay_time_offset_s
+                    if aligned_val >= 0:
+                        entry[dst_key] = aligned_val
 
     @staticmethod
     def _fill_missing_official_tyre_life(result):


### PR DESCRIPTION
Closes #284

## Summary

Introduces a new **Lap Time Evolution** insight window under **Race Analysis**. The feature is designed for race-pace analysis rather than raw telemetry inspection, combining lap times, tyre context, pit-stop events, neutralization overlays, and race-gap context in a single interactive chart.

This PR also includes follow-up fixes made after the initial branch push so that the chart semantics, controls, and default views are accurate and usable in real race sessions.

## Features

### Core Visualisation

- **Per-driver lap-time traces** using the existing driver colour palette
- **Tyre compound markers** per lap:
  - Soft `●`
  - Medium `■`
  - Hard `▲`
  - Intermediate `◆`
  - Wet `★`
- **Stint-average dashed lines** and faint tyre-coloured stint bands for focused drivers
- **Pit-stop markers** for focused drivers

### Race Context Overlays

- **Safety Car**, **Virtual Safety Car**, and **Red Flag** spans rendered as shaded labelled zones
- Correct SC/VSC/RED colour handling when multiple status periods occur in the same session
- **Pure Pace** mode to hide SC/VSC and pit-distorted laps

### View Modes

| Mode | Meaning | Use Case |
|------|---------|----------|
| **Lap Time** | Driver lap time for each completed lap | Pace comparison, tyre degradation, stint quality |
| **Gap to Leader** | Timing-line gap to the race leader after each completed lap | Race-gap trend, convergence/divergence, stop-loss context |

### Interactive Controls

| Control | Action |
|---------|--------|
| Scroll / Pinch | Zoom |
| Click & Drag | Pan |
| Double-click | Reset view to mode home view |
| Axis Limits | Enter exact X/Y ranges |
| Undo / Redo buttons | Navigate chart-view history |
| Driver Dropdown | Show all drivers or isolate one driver |
| Click Legend | Toggle driver focus / multi-select |
| Hover | Show lap, tyre, tyre age, gap/lap-time context |
| `?` Button | Open feature/help overlay |

### Best-Lap Indicators

- **Session Best Lap Time** marker
- **Personal Best Lap Time** marker per driver
- In **Lap Time** mode, personal-best tooltips also show **Gap to SB**

## Important Follow-up Fixes Included

These changes are part of the branch state that should be reviewed, even though they were made after the original commit was first pushed:

1. **Gap mode semantics fixed**
   - The original implementation used a lap-time delta proxy.
   - The chart now uses **lap completion timestamps** so `Gap to Leader` reflects the race-timing concept users expect.

2. **SC/VSC/RED overlay colouring fixed**
   - Status-zone colour rebinding now works correctly across consecutive mixed status periods.

3. **Mode-switch blank-chart issue fixed**
   - Switching between `Lap Time` and `Gap to Leader` no longer leaves stale y-limits that can hide the plot.

4. **Gap-mode scaling improved**
   - Long pit/garage-stop outliers no longer flatten the default competitive field view.
   - Focusing a driver in `Gap to Leader` now isolates the trace without re-scaling the chart around extreme outliers.

5. **Tooltip clarity improved**
   - `Gap to Leader` tooltips now use race-gap wording instead of ambiguous lap-time wording.
   - `Lap Time` personal-best tooltips now show `Gap to SB`.

6. **View controls improved**
   - Added **Axis Limits**
   - Added **Undo / Redo** buttons for chart-view navigation
   - Removed unstable shortcut-only dependence
   - Suppressed hover tooltips while the cursor is over the legend so legend interaction is cleaner

## Files

### New Files

| File | Description |
|------|-------------|
| `src/insights/lap_time_chart_window.py` | Main chart window, rendering, interaction, overlays, HUD, tooltips, zoom/pan controls |

### Modified Files

| File | Description |
|------|-------------|
| `src/gui/insights_menu.py` | Adds the Lap Time Evolution entry under Race Analysis |
| `src/interfaces/race_replay.py` | Precomputes lap-time payload and status-lap data; now includes lap completion timestamps for accurate gap mode |

## Visual Demo

https://github.com/user-attachments/assets/8de1e619-9034-46cf-ac85-f5022a1a4e9d

## Key Design Decisions

1. **Offline computation**
   - Lap times and status periods are precomputed once rather than derived during live rendering.
   - This keeps the UI responsive during replay.

2. **Gap mode uses timing-line completion data**
   - `Gap to Leader` is based on race timing context, not “fastest visible lap” heuristics.

3. **Focused-driver gap view keeps stable default scaling**
   - Selecting a driver should improve readability, not distort it around large outliers.

4. **Interactive state is part of the UX**
   - The chart preserves mode-specific view state and supports explicit axis control for closer inspection.

## Known Limitations / Future Work

- The chart uses **matplotlib + QtAgg**, which is adequate here but not ideal for very high-frequency interactive workloads or when higher FPS is needed.
- If future work adds heavier real-time interaction or cross-session comparison, a faster charting backend may be worth evaluating.

## Tests performed

- Tested and validated across different seasons and different seasons.
- Everything works as mentioned with various edge cases handled as mentioned.

## Update

Since the initial push, this PR has been amended to address several correctness and UX issues in the Lap Time Evolution window:

- corrected Gap to Leader semantics to use lap-completion timing at the line
- fixed SC/VSC/Red Flag zone colouring during redraw
- fixed mode-switch blank-chart / y-axis state issues
- improved gap-mode scaling so focused-driver views do not get squashed by extreme outlier gaps
- refined tooltip content and best-lap labeling
- added axis-limits controls and button-based view history navigation
- stabilized the top-right live lap/time readout and added help/legend shortcuts (`H`, `I`)
- improved legend hover handling and other interaction polish

Note: changes/fixes have been force pushed into a single commit to mitigate from the ongoing incorrect squash merge issue of GitHub.