### PR TITLE
Fix telemetry stability and cache infrastructure issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Run tests
+        run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# F1 Race Replay 🏎️ 🏁
+# F1 Race Replay
 
 A Python application for visualizing Formula 1 race telemetry and replaying race events with interactive controls and a graphical interface.
 
@@ -9,7 +9,7 @@ A Python application for visualizing Formula 1 race telemetry and replaying race
 ## Features
 
 - **Race Replay Visualization:** Watch the race unfold with real-time driver positions on a rendered track.
-- **Safety Car Visualization:** See the Safety Car deploy from pit lane, lead the field, and return to pits — with animated transitions and pulsing glow effects.
+- **Safety Car Visualization:** See the Safety Car deploy from pit lane, lead the field, and return to pits - with animated transitions and pulsing glow effects.
 - **Insights Menu:** Floating menu for quick access to telemetry analysis tools (launches automatically with replay).
 - **Leaderboard:** See live driver positions and current tyre compounds.
 - **Lap & Time Display:** Track the current lap and total race time.
@@ -21,9 +21,9 @@ A Python application for visualizing Formula 1 race telemetry and replaying race
 ## Controls
 
 - **Pause/Resume:** SPACE or Pause button
-- **Rewind/Fast Forward:** ← / → or Rewind/Fast Forward buttons
-- **Playback Speed:** ↑ / ↓ or Speed button (cycles through 0.5x, 1x, 2x, 4x)
-- **Set Speed Directly:** Keys 1–4
+- **Rewind/Fast Forward:** Left / Right arrows or Rewind/Fast Forward buttons
+- **Playback Speed:** Up / Down arrows or Speed button (cycles through 0.5x, 1x, 2x, 4x)
+- **Set Speed Directly:** Keys 1-4
 - **Restart**: **R** to restart replay
 - **Toggle DRS Zone**: **D** to hide/show DRS Zone
 - **Toggle Progress Bar**: **B** to hide/show progress bar
@@ -40,9 +40,9 @@ The replay includes a **simulated Safety Car** that appears on track whenever th
 - **Data source:** The Safety Car deployment timing comes from the real F1 track status data via FastF1 (`session.track_status`).
 - **Position simulation:** The SC is placed ~500 meters ahead of the race leader on the track reference polyline. This approximates where the real SC would be relative to the field.
 - **Three animation phases:**
-  - **Deploying** — The SC animates from the pit lane onto the track over ~3 seconds, with a pulsing glow and "SC DEPLOYING" label.
-  - **On Track** — The SC drives ahead of the leader with a steady amber glow and "SC" label.
-  - **Returning** — The SC animates back to the pit lane over ~3 seconds, with a fading pulsing glow and "SC IN" label.
+  - **Deploying** - The SC animates from the pit lane onto the track over ~3 seconds, with a pulsing glow and "SC DEPLOYING" label.
+  - **On Track** - The SC drives ahead of the leader with a steady amber glow and "SC" label.
+  - **Returning** - The SC animates back to the pit lane over ~3 seconds, with a fading pulsing glow and "SC IN" label.
 - **Visual appearance:** The SC is drawn as a larger orange/amber circle (8px radius vs 6px for regular cars) with an orange outline ring and always-visible "SC" label.
 
 ### Technical details
@@ -66,7 +66,7 @@ The SC position computation happens in `_compute_safety_car_positions()` in `src
 | `phase` | `"deploying"`, `"on_track"`, or `"returning"` |
 | `alpha` | Opacity value from `0.0` (invisible) to `1.0` (fully visible), used for fade in/out animation |
 
-> **Note:** If you have existing cached `.pkl` files from previous runs, you must re-run with `--refresh-data` to generate SC position data. Older cached files will simply show no Safety Car.
+> **Note:** Computed telemetry caches include a schema version. Older cached files are ignored automatically and regenerated when the cache format changes.
 
 ## Qualifying Session Support (in development)
 
@@ -178,24 +178,24 @@ python main.py --viewer --year 2025 --round 12 --qualifying --sprint
 
 ```
 f1-race-replay/
-├── main.py                    # Entry point, handles session loading and starts the replay
-├── requirements.txt           # Python dependencies
-├── README.md                  # Project documentation
-├── roadmap.md                 # Planned features and project vision
-├── resources/
-│   └── preview.png           # Race replay preview image
-├── src/
-│   ├── f1_data.py            # Telemetry loading, processing, frame generation & SC position simulation
-│   ├── arcade_replay.py      # Visualization and UI logic
-│   └── ui_components.py      # UI components like buttons and leaderboard
-│   ├── interfaces/
-│   │   └── qualifying.py     # Qualifying session interface and telemetry visualization
-│   │   └── race_replay.py    # Race replay interface, SC rendering & telemetry visualization
-│   └── lib/
-│       └── tyres.py          # Type definitions for telemetry data structures
-│       └── time.py           # Time formatting utilities
-└── .fastf1-cache/            # FastF1 cache folder (created automatically upon first run)
-└── computed_data/            # Computed telemetry data (created automatically upon first run)
+|-- main.py                    # Entry point, handles session loading and starts the replay
+|-- requirements.txt           # Python dependencies
+|-- README.md                  # Project documentation
+|-- roadmap.md                 # Planned features and project vision
+|-- resources/
+|   `-- preview.png            # Race replay preview image
+|-- src/
+|   |-- f1_data.py             # Telemetry loading, processing, frame generation & SC position simulation
+|   |-- ui_components.py       # UI components like buttons and leaderboard
+|   |-- interfaces/
+|   |   |-- qualifying.py      # Qualifying session interface and telemetry visualization
+|   |   `-- race_replay.py     # Race replay interface, SC rendering & telemetry visualization
+|   `-- lib/
+|       |-- tyres.py           # Tyre compound helpers
+|       |-- time.py            # Time formatting utilities
+|       `-- cache.py           # Computed-data cache helpers
+|-- .fastf1-cache/             # FastF1 cache folder (created automatically upon first run)
+`-- computed_data/             # Computed telemetry data (created automatically upon first run)
 ```
 
 ## Building Custom Telemetry Windows
@@ -226,12 +226,12 @@ The `PitWallWindow` base class handles all telemetry stream connection logic aut
 **Documentation & Examples:**
 - See [docs/PitWallWindow.md](./docs/PitWallWindow.md) for complete guide
 - See [docs/InsightsMenu.md](./docs/InsightsMenu.md) for adding insights to the menu
-- Run the example: `python -m src.gui.example_pit_wall_window`
+- Run the example: `python -m src.insights.example_pit_wall_window`
 - Test the menu: `python -m src.gui.insights_menu`
 
 ## Customization
 
-- Change track width, colors, and UI layout in `src/arcade_replay.py`.
+- Change track width, colors, and UI layout in `src/interfaces/race_replay.py` and `src/ui_components.py`.
 - Adjust telemetry processing in `src/f1_data.py`.
 - Create custom telemetry windows using `PitWallWindow` base class (see above).
 

--- a/docs/InsightsMenu.md
+++ b/docs/InsightsMenu.md
@@ -217,4 +217,4 @@ def create_insight_button(self, name, description, callback):
 
 - [PitWallWindow.md](./PitWallWindow.md) - Base class for creating insights
 - [../src/gui/insights_menu.py](../src/gui/insights_menu.py) - Menu implementation
-- [../src/gui/example_pit_wall_window.py](../src/gui/example_pit_wall_window.py) - Example insight
+- [../src/insights/example_pit_wall_window.py](../src/insights/example_pit_wall_window.py) - Example insight

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyglet
 pyside6
 questionary
 rich
+scipy

--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -1,6 +1,5 @@
 import math
 import os
-import pickle
 import sys
 from datetime import timedelta, date
 from multiprocessing import Pool, cpu_count
@@ -13,6 +12,11 @@ import pandas as pd
 from src.lib.settings import get_settings
 from src.lib.time import parse_time_string
 from src.lib.tyres import get_tyre_compound_int
+from src.lib.cache import (
+    get_computed_data_file,
+    load_cached_payload,
+    save_cached_payload,
+)
 
 def enable_cache():
     # Get cache location from settings
@@ -97,6 +101,9 @@ def _process_single_driver(args):
         drs_all.append(drs_lap)
         throttle_all.append(throttle_lap)
         brake_all.append(brake_lap)
+        lap_distance = np.nanmax(d_lap) if len(d_lap) else 0.0
+        if np.isfinite(lap_distance) and lap_distance > 0:
+            total_dist_so_far += float(lap_distance)
 
     if not t_all:
         return None
@@ -539,20 +546,19 @@ def _compute_safety_car_positions(frames, track_statuses, session):
 def get_race_telemetry(session, session_type="R"):
     event_name = str(session).replace(" ", "_")
     cache_suffix = "sprint" if session_type == "S" else "race"
+    cache_path = get_computed_data_file(
+        f"{event_name}_{cache_suffix}_telemetry.pkl",
+        create_dir=False,
+    )
 
     # Check if this data has already been computed
 
-    try:
-        if "--refresh-data" not in sys.argv:
-            with open(
-                f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "rb"
-            ) as f:
-                frames = pickle.load(f)
-                print(f"Loaded precomputed {cache_suffix} telemetry data.")
-                print("The replay should begin in a new window shortly!")
-                return frames
-    except FileNotFoundError:
-        pass  # Need to compute from scratch
+    if "--refresh-data" not in sys.argv:
+        cached = load_cached_payload(cache_path)
+        if cached is not None:
+            print(f"Loaded precomputed {cache_suffix} telemetry data.")
+            print("The replay should begin in a new window shortly!")
+            return cached
 
     drivers = session.drivers
 
@@ -914,24 +920,8 @@ def get_race_telemetry(session, session_type="R"):
     _compute_safety_car_positions(frames, formatted_track_statuses, session)
     print("completed telemetry extraction...")
     print("Saving to cache file...")
-    # If computed_data/ directory doesn't exist, create it
-    if not os.path.exists("computed_data"):
-        os.makedirs("computed_data")
-
-    # Save using pickle (10-100x faster than JSON)
-    with open(f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "wb") as f:
-        pickle.dump({
-            "frames": frames,
-            "driver_colors": get_driver_colors(session),
-            "track_statuses": formatted_track_statuses,
-            "race_control_messages": formatted_rc_messages,
-            "total_laps": int(max_lap_number),
-            "max_tyre_life": max_tyre_life_map,
-        }, f, protocol=pickle.HIGHEST_PROTOCOL)
-
-    print("Saved Successfully!")
-    print("The replay should begin in a new window shortly")
-    return {
+    cache_path = get_computed_data_file(f"{event_name}_{cache_suffix}_telemetry.pkl")
+    payload = {
         "frames": frames,
         "driver_colors": get_driver_colors(session),
         "track_statuses": formatted_track_statuses,
@@ -939,6 +929,11 @@ def get_race_telemetry(session, session_type="R"):
         "total_laps": int(max_lap_number),
         "max_tyre_life": max_tyre_life_map,
     }
+    save_cached_payload(cache_path, payload)
+
+    print("Saved Successfully!")
+    print("The replay should begin in a new window shortly")
+    return payload
 
 
 def get_qualifying_results(session):
@@ -1332,19 +1327,18 @@ def get_quali_telemetry(session, session_type="Q"):
 
     event_name = str(session).replace(" ", "_")
     cache_suffix = "sprintquali" if session_type == "SQ" else "quali"
+    cache_path = get_computed_data_file(
+        f"{event_name}_{cache_suffix}_telemetry.pkl",
+        create_dir=False,
+    )
 
     # Check if this data has already been computed
-    try:
-        if "--refresh-data" not in sys.argv:
-            with open(
-                f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "rb"
-            ) as f:
-                data = pickle.load(f)
-                print(f"Loaded precomputed {cache_suffix} telemetry data.")
-                print("The replay should begin in a new window shortly!")
-                return data
-    except FileNotFoundError:
-        pass  # Need to compute from scratch
+    if "--refresh-data" not in sys.argv:
+        cached = load_cached_payload(cache_path)
+        if cached is not None:
+            print(f"Loaded precomputed {cache_suffix} telemetry data.")
+            print("The replay should begin in a new window shortly!")
+            return cached
 
     qualifying_results = get_qualifying_results(session)
 
@@ -1379,29 +1373,18 @@ def get_quali_telemetry(session, session_type="Q"):
         if result["min_speed"] < min_speed or min_speed == 0.0:
             min_speed = result["min_speed"]
 
-    # Save to the compute_data directory
-
-    if not os.path.exists("computed_data"):
-        os.makedirs("computed_data")
-
-    with open(f"computed_data/{event_name}_{cache_suffix}_telemetry.pkl", "wb") as f:
-        pickle.dump(
-            {
-                "results": qualifying_results,
-                "telemetry": telemetry_data,
-                "max_speed": max_speed,
-                "min_speed": min_speed,
-            },
-            f,
-            protocol=pickle.HIGHEST_PROTOCOL,
-        )
-
-    return {
+    payload = {
         "results": qualifying_results,
         "telemetry": telemetry_data,
         "max_speed": max_speed,
         "min_speed": min_speed,
     }
+    save_cached_payload(
+        get_computed_data_file(f"{event_name}_{cache_suffix}_telemetry.pkl"),
+        payload,
+    )
+
+    return payload
 
 
 def get_race_weekends_by_year(year):

--- a/src/insights/race_control_feed_window.py
+++ b/src/insights/race_control_feed_window.py
@@ -84,8 +84,8 @@ def _clean_sector(val):
 _WAITING_TEXT = "Waiting for race control messages..."
 _NO_DATA_TEXT = (
     "No race control data in cache.\n\n"
-    "Delete the .pkl file in computed_data/\n"
-    "and re-run the session to regenerate."
+    "Re-run the session with --refresh-data\n"
+    "to regenerate the computed cache."
 )
 
 

--- a/src/insights/tyre_strategy_window.py
+++ b/src/insights/tyre_strategy_window.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QFont, QPainter, QColor, QPen, QBrush, QLinearGradient
 from PySide6.QtCore import Qt, QRect, QTimer
 from src.gui.pit_wall_window import PitWallWindow
+from src.lib.cache import get_computed_data_file
 
 
 TYRE_COLOURS = {
@@ -204,8 +205,9 @@ class TyreStrategyWindow(PitWallWindow):
     def _load_state(self):
         try:
             import json, os
-            if os.path.exists("computed_data/tyre_state.json"):
-                with open("computed_data/tyre_state.json") as f:
+            state_path = get_computed_data_file("tyre_state.json", create_dir=False)
+            if os.path.exists(state_path):
+                with open(state_path) as f:
                     saved = json.load(f)
                     self.stints      = saved.get("stints", {})
                     self.positions   = saved.get("positions", {})
@@ -222,10 +224,8 @@ class TyreStrategyWindow(PitWallWindow):
 
     def _save_state(self):
         try:
-            import json, os
-            if not os.path.exists("computed_data"):
-                os.makedirs("computed_data")
-            with open("computed_data/tyre_state.json", "w") as f:
+            import json
+            with open(get_computed_data_file("tyre_state.json"), "w") as f:
                 json.dump({
                     "stints":      self.stints,
                     "positions":   self.positions,

--- a/src/lib/cache.py
+++ b/src/lib/cache.py
@@ -1,0 +1,47 @@
+import os
+import pickle
+from pathlib import Path
+from typing import Any, Optional
+
+from src.lib.settings import get_settings
+
+
+CACHE_SCHEMA_VERSION = 2
+_CACHE_SCHEMA_KEY = "_cache_schema_version"
+_CACHE_PAYLOAD_KEY = "payload"
+
+
+def get_computed_data_dir(create: bool = True) -> Path:
+    path = Path(get_settings().computed_data_location).expanduser()
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_computed_data_file(filename: str, create_dir: bool = True) -> Path:
+    return get_computed_data_dir(create=create_dir) / filename
+
+
+def load_cached_payload(path: os.PathLike[str] | str) -> Optional[Any]:
+    try:
+        with open(path, "rb") as f:
+            cached = pickle.load(f)
+    except (EOFError, FileNotFoundError, pickle.UnpicklingError):
+        return None
+
+    if not isinstance(cached, dict):
+        return None
+
+    if cached.get(_CACHE_SCHEMA_KEY) != CACHE_SCHEMA_VERSION:
+        return None
+
+    return cached.get(_CACHE_PAYLOAD_KEY)
+
+
+def save_cached_payload(path: os.PathLike[str] | str, payload: Any) -> None:
+    wrapped = {
+        _CACHE_SCHEMA_KEY: CACHE_SCHEMA_VERSION,
+        _CACHE_PAYLOAD_KEY: payload,
+    }
+    with open(path, "wb") as f:
+        pickle.dump(wrapped, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/telemetry.md
+++ b/telemetry.md
@@ -8,12 +8,12 @@ This document provides instructions on how to use the telemetry stream feature w
 
 Ensure you have the latest version of the application with telemetry support and have already setup an environment with the required dependencies (see `README.md` for setup instructions).
 
-1. **Start the F1 Race Replay and pass the --telemetry flag:**
+1. **Start a race replay.** The telemetry stream starts automatically for race sessions:
    ```bash
-   python main.py --telemetry
+   python main.py --viewer --year 2025 --round 12
    ```
 
-2. **Select a race session from the GUI.** The telemetry stream will start automatically when the replay begins.
+2. **Or start from the GUI and select a race session.** The telemetry stream will start when the replay window opens.
 
 3. **The demo window will show:**
    - **Raw telemetry stream**: JSON data as it comes from the race replay
@@ -93,7 +93,7 @@ The `safety_car` field in each frame contains the simulated Safety Car position 
 | `x` | float | World X coordinate of the Safety Car |
 | `y` | float | World Y coordinate of the Safety Car |
 | `phase` | string | Current animation phase: `"deploying"`, `"on_track"`, or `"returning"` |
-| `alpha` | float | Opacity value `0.0`–`1.0` for fade animation |
+| `alpha` | float | Opacity value `0.0`-`1.0` for fade animation |
 
 > **Note:** The Safety Car position is simulated (placed ~500m ahead of the race leader) since the F1 API does not provide real SC GPS data. The `phase` field is useful for triggering visual effects in custom tools.
 

--- a/tests/test_settings_and_cache.py
+++ b/tests/test_settings_and_cache.py
@@ -1,0 +1,66 @@
+import pickle
+
+from src.lib.settings import SettingsManager
+
+
+def _reset_settings_singleton(monkeypatch, tmp_path):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    SettingsManager._instance = None
+
+
+def test_settings_default_computed_data_location(monkeypatch, tmp_path):
+    _reset_settings_singleton(monkeypatch, tmp_path)
+
+    settings = SettingsManager()
+
+    assert settings.computed_data_location == "computed_data"
+
+
+def test_computed_data_file_uses_configured_location(monkeypatch, tmp_path):
+    _reset_settings_singleton(monkeypatch, tmp_path)
+
+    settings = SettingsManager()
+    settings.computed_data_location = str(tmp_path / "custom-computed")
+
+    from src.lib.cache import get_computed_data_file
+
+    path = get_computed_data_file("sample.pkl")
+
+    assert path == tmp_path / "custom-computed" / "sample.pkl"
+    assert path.parent.exists()
+
+
+def test_cache_round_trip_uses_schema_wrapper(tmp_path):
+    from src.lib.cache import CACHE_SCHEMA_VERSION, load_cached_payload, save_cached_payload
+
+    path = tmp_path / "cache.pkl"
+    payload = {"frames": [1, 2, 3]}
+
+    save_cached_payload(path, payload)
+
+    with open(path, "rb") as f:
+        raw = pickle.load(f)
+
+    assert raw["_cache_schema_version"] == CACHE_SCHEMA_VERSION
+    assert load_cached_payload(path) == payload
+
+
+def test_cache_loader_rejects_legacy_unversioned_payload(tmp_path):
+    from src.lib.cache import load_cached_payload
+
+    path = tmp_path / "legacy.pkl"
+    with open(path, "wb") as f:
+        pickle.dump({"frames": []}, f)
+
+    assert load_cached_payload(path) is None
+
+
+def test_cache_loader_rejects_incompatible_schema(tmp_path):
+    from src.lib.cache import load_cached_payload
+
+    path = tmp_path / "future.pkl"
+    with open(path, "wb") as f:
+        pickle.dump({"_cache_schema_version": 999, "payload": {"frames": []}}, f)
+
+    assert load_cached_payload(path) is None
+

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,18 @@
+from src.lib.time import format_time, parse_time_string
+
+
+def test_format_time_handles_invalid_values():
+    assert format_time(None) == "N/A"
+    assert format_time(-1) == "N/A"
+
+
+def test_format_time_formats_seconds():
+    assert format_time(86.1234) == "01:26.123"
+
+
+def test_parse_time_string_supports_common_fastf1_formats():
+    assert parse_time_string("0 days 00:01:27.060000") == 87.06
+    assert parse_time_string("00:01:26.123000") == 86.123
+    assert parse_time_string("01:26.123") == 86.123
+    assert parse_time_string("01:26") == 86.0
+

--- a/tests/test_tyres.py
+++ b/tests/test_tyres.py
@@ -1,0 +1,13 @@
+from src.lib.tyres import get_tyre_compound_int, get_tyre_compound_str
+
+
+def test_known_tyre_compounds_round_trip():
+    for compound in ["SOFT", "MEDIUM", "HARD", "INTERMEDIATE", "WET"]:
+        compound_id = get_tyre_compound_int(compound)
+        assert get_tyre_compound_str(compound_id) == compound
+
+
+def test_unknown_tyre_compounds_are_stable():
+    assert get_tyre_compound_int("not-a-compound") == -1
+    assert get_tyre_compound_str(-1) == "UNKNOWN"
+


### PR DESCRIPTION
## Summary
- Add missing scipy runtime dependency
- Fix cumulative race distance accumulation during telemetry extraction
- Route computed-data cache/state files through configured settings
- Add minimal cache schema versioning and safe invalidation
- Repair stale docs for telemetry and insight examples
- Add lightweight pytest coverage and a minimal CI workflow

## Testing
- git diff --check
- pytest not run locally because Python is unavailable on PATH in this environment

## Manual Validation
- Run `python -m pytest`
- Run `python main.py --viewer --year 2025 --round 12 --refresh-data`
- Confirm a new versioned telemetry cache is created
- Re-run without `--refresh-data` and confirm cache load
- Change computed data location in Settings and confirm new files are written there
