### PR TITLE
Add community templates and initial test suite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug report
+description: Report a reproducible problem in f1-race-replay
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please include enough detail to help reproduce the issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: Project version / commit
+      description: Which branch, commit, or release are you using?
+      placeholder: "main @ commit SHA, or release version"
+    validations:
+      required: false
+
+  - type: input
+    id: command
+    attributes:
+      label: Command used
+      description: Paste the command that triggered the issue.
+      placeholder: "python main.py --year 2025 --round 1"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface
+      options:
+        - CLI
+        - GUI
+        - Race replay window
+        - Insights / telemetry window
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps needed to reproduce the issue.
+      placeholder: |
+        1. Run ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Paste any relevant logs, terminal output, or Python traceback.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Python version, package manager, and whether you use Conda/venv.
+      placeholder: |
+        OS:
+        Python:
+        Environment: venv / Conda / system Python
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: Add screenshots or short recordings if they help explain the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/IAmTomShaw/f1-race-replay/discussions
+    about: Please use discussions for open-ended questions, ideas, or general help if enabled for the repository.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation request
+description: Suggest an improvement to documentation
+title: "[DOCS] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation location
+      description: Which file, section, or page should be improved?
+      placeholder: "README.md, telemetry.md, docs/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is unclear or missing?
+      description: Explain the documentation problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Suggest wording, examples, screenshots, or structure changes.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature request
+description: Suggest an improvement or new feature
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe the user problem first, then the proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem would this feature solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered another approach or workaround?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the project
+      options:
+        - Race replay
+        - Telemetry / insights
+        - CLI
+        - GUI
+        - Track visualization
+        - Data loading
+        - Documentation
+        - Developer tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add examples, screenshots, links, or implementation ideas.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe the changes introduced by this pull request.
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor / maintenance
+- [ ] Tests / tooling
+
+## Testing
+
+Describe how you tested the change.
+
+Example command:
+
+    python -m pytest
+
+## Checklist
+
+- [ ] I have kept the change focused and easy to review.
+- [ ] I have tested the affected behavior locally.
+- [ ] I have updated documentation where needed.
+- [ ] I have avoided committing generated files, caches, or local environment files.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    name: Python tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: |
+          python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,24 @@
-
+# Virtual environments
 venv/
+.venv/
+env/
 
-output_animation.mp4
-.fastf1-cache
-still_frame.png
-
-.mypy_cache/
+# Python caches
 __pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
 
+# Local FastF1/cache/generated data
+.fastf1-cache
 computed_data/
 
+# Generated media/output
+output_animation.mp4
+still_frame.png
+
+# OS / IDE files
 .DS_Store
-.idea
+.idea/
+.vscode/

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,44 @@
+# Testing
+
+This project uses `pytest` for automated tests.
+
+## Install test dependencies
+
+For local development, create and activate a virtual environment first:
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+
+Then install the development requirements:
+
+    python -m pip install --upgrade pip
+    python -m pip install -r requirements-dev.txt
+
+## Run the test suite
+
+Run all tests with:
+
+    python -m pytest
+
+Run only the lightweight unit tests with:
+
+    python -m pytest tests/lib
+
+## Test strategy
+
+The initial test suite focuses on lightweight modules that do not require:
+
+- live FastF1 data downloads
+- opening GUI windows
+- an OpenGL context
+- a running race replay session
+
+The current suite includes:
+
+- unit tests for time formatting and parsing
+- unit tests for tyre compound mapping
+- unit tests for season detection
+- unit tests for settings persistence with temporary files
+- smoke import tests for project modules
+
+Some import smoke tests may be skipped locally when optional runtime dependencies are not installed.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest
+pytest-mock

--- a/tests/lib/test_season.py
+++ b/tests/lib/test_season.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+import src.lib.season as season
+
+
+class FixedDate(datetime):
+    fixed_now = datetime(2025, 3, 1)
+
+    @classmethod
+    def now(cls):
+        return cls.fixed_now
+
+
+def test_get_season_returns_current_year_from_february(monkeypatch):
+    FixedDate.fixed_now = datetime(2025, 2, 1)
+    monkeypatch.setattr(season, "date", FixedDate)
+
+    assert season.get_season() == 2025
+
+
+def test_get_season_returns_current_year_after_february(monkeypatch):
+    FixedDate.fixed_now = datetime(2025, 7, 15)
+    monkeypatch.setattr(season, "date", FixedDate)
+
+    assert season.get_season() == 2025
+
+
+def test_get_season_returns_previous_year_in_january(monkeypatch):
+    FixedDate.fixed_now = datetime(2025, 1, 15)
+    monkeypatch.setattr(season, "date", FixedDate)
+
+    assert season.get_season() == 2024

--- a/tests/lib/test_settings.py
+++ b/tests/lib/test_settings.py
@@ -1,0 +1,122 @@
+import json
+from pathlib import Path
+
+from src.lib.settings import SettingsManager
+
+
+def reset_settings_singleton():
+    SettingsManager._instance = None
+
+
+def test_settings_manager_loads_defaults(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+
+    assert manager.cache_location == ".fastf1-cache"
+    assert manager.computed_data_location == "computed_data"
+
+
+def test_settings_manager_reads_existing_json_file(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(
+        json.dumps(
+            {
+                "cache_location": "custom-cache",
+                "computed_data_location": "custom-data",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+
+    assert manager.cache_location == "custom-cache"
+    assert manager.computed_data_location == "custom-data"
+
+
+def test_settings_manager_set_and_get_values(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+    manager.set("example_key", "example-value")
+
+    assert manager.get("example_key") == "example-value"
+    assert manager.get("missing_key", "fallback") == "fallback"
+
+
+def test_settings_manager_property_setters(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+    manager.cache_location = "cache-dir"
+    manager.computed_data_location = "computed-dir"
+
+    assert manager.cache_location == "cache-dir"
+    assert manager.computed_data_location == "computed-dir"
+
+
+def test_settings_manager_save_writes_json_file(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+    manager.cache_location = "saved-cache"
+    manager.save()
+
+    saved_data = json.loads(settings_file.read_text(encoding="utf-8"))
+
+    assert saved_data["cache_location"] == "saved-cache"
+
+
+def test_settings_manager_reset_to_defaults(monkeypatch, tmp_path):
+    reset_settings_singleton()
+    settings_file = tmp_path / "settings.json"
+
+    monkeypatch.setattr(
+        SettingsManager,
+        "_get_settings_file_path",
+        lambda self: settings_file,
+    )
+
+    manager = SettingsManager()
+    manager.cache_location = "custom-cache"
+
+    manager.reset_to_defaults()
+
+    assert manager.cache_location == ".fastf1-cache"
+    assert manager.computed_data_location == "computed_data"

--- a/tests/lib/test_time.py
+++ b/tests/lib/test_time.py
@@ -1,0 +1,50 @@
+import pytest
+
+from src.lib.time import format_time, parse_time_string
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "00:00.000"),
+        (1.234, "00:01.234"),
+        (61.5, "01:01.500"),
+        (3661.25, "61:01.250"),
+    ],
+)
+def test_format_time_valid_values(seconds, expected):
+    assert format_time(seconds) == expected
+
+
+@pytest.mark.parametrize("seconds", [None, -1, -10.5])
+def test_format_time_invalid_values(seconds):
+    assert format_time(seconds) == "N/A"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("00:01:26:123000", 86.123),
+        ("00:01:26.123000", 86.123),
+        ("01:26.123", 86.123),
+        ("01:26", 86.0),
+        ("0 days 00:01:27.060000", 87.06),
+        ("00:01:26.123000 extra text", 86.123),
+    ],
+)
+def test_parse_time_string_supported_formats(value, expected):
+    assert parse_time_string(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "not-a-time",
+        "1",
+        "::::",
+        None,
+    ],
+)
+def test_parse_time_string_invalid_values(value):
+    assert parse_time_string(value) is None

--- a/tests/lib/test_tyres.py
+++ b/tests/lib/test_tyres.py
@@ -1,0 +1,69 @@
+import pytest
+
+from src.lib.tyres import get_tyre_compound_int, get_tyre_compound_str
+
+
+@pytest.mark.parametrize(
+    ("compound", "expected"),
+    [
+        ("SOFT", 0),
+        ("MEDIUM", 1),
+        ("HARD", 2),
+        ("INTERMEDIATE", 3),
+        ("WET", 4),
+    ],
+)
+def test_get_tyre_compound_int_known_compounds(compound, expected):
+    assert get_tyre_compound_int(compound) == expected
+
+
+@pytest.mark.parametrize(
+    ("compound", "expected"),
+    [
+        ("soft", 0),
+        ("medium", 1),
+        ("hard", 2),
+        ("intermediate", 3),
+        ("wet", 4),
+    ],
+)
+def test_get_tyre_compound_int_is_case_insensitive(compound, expected):
+    assert get_tyre_compound_int(compound) == expected
+
+
+@pytest.mark.parametrize(
+    "compound",
+    [
+        "UNKNOWN",
+        "SUPERSOFT",
+        "",
+    ],
+)
+def test_get_tyre_compound_int_unknown_compounds(compound):
+    assert get_tyre_compound_int(compound) == -1
+
+
+@pytest.mark.parametrize(
+    ("compound_id", "expected"),
+    [
+        (0, "SOFT"),
+        (1, "MEDIUM"),
+        (2, "HARD"),
+        (3, "INTERMEDIATE"),
+        (4, "WET"),
+    ],
+)
+def test_get_tyre_compound_str_known_ids(compound_id, expected):
+    assert get_tyre_compound_str(compound_id) == expected
+
+
+@pytest.mark.parametrize(
+    "compound_id",
+    [
+        -1,
+        5,
+        999,
+    ],
+)
+def test_get_tyre_compound_str_unknown_ids(compound_id):
+    assert get_tyre_compound_str(compound_id) == "UNKNOWN"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,56 @@
+import importlib
+
+import pytest
+
+
+MODULES = [
+    "src.bayesian_tyre_model",
+    "src.cli.race_selection",
+    "src.f1_data",
+    "src.gui.insights_menu",
+    "src.gui.pit_wall_window",
+    "src.gui.pit_wall_window_template",
+    "src.gui.race_selection",
+    "src.gui.settings_dialog",
+    "src.insights.driver_telemetry_window",
+    "src.insights.example_pit_wall_window",
+    "src.insights.race_control_feed_window",
+    "src.insights.telemetry_stream_viewer",
+    "src.insights.track_position_window",
+    "src.insights.tyre_strategy_window",
+    "src.interfaces.qualifying",
+    "src.interfaces.race_replay",
+    "src.lib.season",
+    "src.lib.settings",
+    "src.lib.time",
+    "src.lib.tyres",
+    "src.run_session",
+    "src.services.stream",
+    "src.tyre_degradation_integration",
+    "src.ui_components",
+]
+
+OPTIONAL_DEPENDENCIES = {
+    "arcade",
+    "fastf1",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "pyglet",
+    "PySide6",
+    "questionary",
+    "rich",
+}
+
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_project_modules_are_importable(module_name):
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        missing_dependency = exc.name.split(".")[0]
+
+        if missing_dependency in OPTIONAL_DEPENDENCIES:
+            pytest.skip(f"optional dependency not installed: {missing_dependency}")
+
+        raise


### PR DESCRIPTION
## Summary

This PR adds a community and testing foundation for the project.

Changes included:

- GitHub issue templates for bug reports, feature requests, and documentation requests
- Pull request template
- Development requirements file
- Pytest configuration
- Initial unit tests for lightweight utility modules
- Smoke import tests for project modules
- GitHub Actions workflow to run tests on Python 3.10, 3.11, and 3.12
- Testing documentation
- Expanded .gitignore for common Python, IDE, and test artifacts

## Related issues

Closes #119
Closes #120

## Testing

Tested locally with:

    python -m pytest

Result:

    72 passed in 10.01s

## Notes

The initial test suite focuses on lightweight unit tests and import smoke tests. It avoids requiring a running race replay session or live user interaction.