### PR TITLE
Fix: Handle empty position telemetry from FastF1 to prevent KeyError crash

### DIFF
--- a/src/f1_data.py
+++ b/src/f1_data.py
@@ -62,7 +62,17 @@ def _process_single_driver(args):
     # iterate laps in order
     for _, lap in laps_driver.iterlaps():
         # get telemetry for THIS lap only
-        lap_tel = lap.get_telemetry()
+        try:
+            lap_tel = lap.get_telemetry()
+        except KeyError as e:
+            # Handle case where FastF1 fails to merge car and position data
+            # due to empty position telemetry (missing 'Date' column)
+            if "'Date'" in str(e):
+                print(f"Warning: Skipping lap {lap.LapNumber} for driver {driver_code} due to missing position telemetry")
+                continue
+            else:
+                # Re-raise if it's a different KeyError
+                raise
         lap_number = lap.LapNumber
         tyre_compund_as_int = get_tyre_compound_int(lap.Compound)
         tyre_life = lap.TyreLife if pd.notna(lap.TyreLife) else 0


### PR DESCRIPTION
Fixes issue #303: Monaco 2026 replay crashes when FastF1 returns empty position telemetry for a lap

When FastF1 returns empty position telemetry data (no columns), lap.get_telemetry() raises a KeyError when trying to merge car and position data by 'Date' column.

This change catches this specific KeyError and skips the affected lap, allowing the replay to continue instead of crashing.

The fix:
- Wraps lap.get_telemetry() in a try-except block
- Catches KeyError related to missing 'Date' column
- Logs a warning and skips the problematic lap
- Re-raises other KeyErrors to avoid masking different issues

This follows the existing pattern in the code where empty telemetry is skipped (lines 70-71).