### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a crash or incorrect behaviour in the replay
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Most replay issues depend on the exact session and the versions in use, so please fill in as much as you can.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: The replay crashed / showed the wrong thing when...
+    validations:
+      required: true
+  - type: input
+    id: session
+    attributes:
+      label: Session being replayed
+      description: Year, Grand Prix, and session type. Many bugs are specific to one session's data.
+      placeholder: "2026 Monaco Grand Prix, Race"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `python main.py`
+        2. Select ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Error output / traceback
+      description: If there was a crash, paste the full traceback. This will be automatically formatted, no backticks needed.
+      render: shell
+  - type: input
+    id: fastf1-version
+    attributes:
+      label: FastF1 version
+      description: "Output of `pip show fastf1`. Several reported bugs were fixed by upgrading FastF1."
+      placeholder: "3.8.1"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.11.9"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not already been reported.
+          required: true
+        - label: I am on the latest version of FastF1 (`pip install --upgrade fastf1`).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FastF1 data questions
+    url: https://docs.fastf1.dev/
+    about: Questions about what telemetry or timing data is available come from FastF1, the upstream data source.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new feature or improvement for the replay
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that the replay does not support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature and, if you can, where in the UI or data pipeline it would fit.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this feature has not already been requested.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing to the F1 Race Replay! -->
+
+## What does this PR do?
+
+<!-- Describe the change and, if it fixes a bug, what was going wrong. -->
+
+## Related issue
+
+<!-- e.g. Fixes #123. If there is no issue, briefly say why the change is needed. -->
+
+## How was this tested?
+
+<!-- Which session(s) did you replay, on which OS and FastF1 version? Screenshots or a short clip help a lot for UI changes. -->
+
+## Checklist
+
+- [ ] I ran the replay locally and it starts without errors.
+- [ ] My change is focused on one thing (separate unrelated changes into their own PRs).
+- [ ] I updated docs or `contributors.md` if relevant.


### PR DESCRIPTION
Fixes #119

Adds GitHub issue forms and a PR template so issues and PRs come in with a consistent shape.

While putting this together I read back through a chunk of the open bug reports to see what information reviewers kept having to ask for. The pattern was pretty clear: a lot of the replay bugs come down to the exact session being replayed, the FastF1 version, the Python version, or the OS. For example #245 turned out to be fixed just by upgrading FastF1 from 3.7.0 to 3.8.1, and #303 was one session's missing position data. So the bug form asks for all of that up front instead of it coming out over several back-and-forth comments.

What's included:
- `.github/ISSUE_TEMPLATE/bug_report.yml` - session, repro steps, traceback (rendered as shell), FastF1/Python versions, OS, and a quick "did you search / are you on latest FastF1" check.
- `.github/ISSUE_TEMPLATE/feature_request.yml` - problem, proposal, alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` - turns off blank issues and links data-availability questions to the FastF1 docs, since that is the upstream source.
- `.github/PULL_REQUEST_TEMPLATE.md` - what/why, related issue, and how it was tested (which session + OS + FastF1 version), plus a note to keep PRs focused.

I validated the issue forms as YAML locally. I did lean on Claude to sanity-check the issue-form schema and cross-reference which past issues were version or session specific, but I went through the templates and the field choices myself. Happy to adjust the wording or fields to match how you'd like issues structured.