### PR TITLE
Fix leaderboard showing wrong order after the race ends (#309)

### DIFF
--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -19,6 +19,7 @@ from src.ui_components import (
 )
 from src.tyre_degradation_integration import TyreDegradationIntegrator
 from src.services.stream import TelemetryStreamServer
+from src.lib.leaderboard import official_finishing_order, order_leaderboard_codes
 
 
 SCREEN_WIDTH = 1280
@@ -68,6 +69,18 @@ class F1RaceReplayWindow(arcade.Window):
         self._precomputed_lap_times = self._compute_lap_times(frames, session)
         self._precomputed_status_laps = self._compute_status_laps(frames, track_statuses)
         self.visible_hud = visible_hud # If it displays HUD or not (leaderboard, controls, weather, etc)
+
+        # Official classified finishing order, used to correct the leaderboard
+        # once the race is over (see issue #309). Falls back to an empty list,
+        # which leaves the live on-track ordering untouched.
+        self.official_finish_order = []
+        if session is not None:
+            try:
+                self.official_finish_order = official_finishing_order(
+                    getattr(session, "results", None)
+                )
+            except Exception as e:
+                print(f"Could not derive official finishing order: {e}")
 
         # Rotation (degrees) to apply to the whole circuit around its centre
         self.circuit_rotation = circuit_rotation
@@ -1528,6 +1541,18 @@ class F1RaceReplayWindow(arcade.Window):
             progress_m = driver_progress.get(code, float(pos.get("dist", 0.0)))
             driver_list.append((code, color, pos, progress_m))
         driver_list.sort(key=lambda x: x[3], reverse=True)
+
+        # Once the race has finished, the live on-track progress is only a proxy
+        # for position and no longer matches the classified result (post-race
+        # penalties, lapped cars, retirements). Show the official finishing
+        # order instead for the frozen end-of-race leaderboard. See issue #309.
+        race_finished = self.n_frames > 0 and int(round(self.frame_index)) >= self.n_frames - 1
+        if race_finished and self.official_finish_order:
+            by_code = {entry[0]: entry for entry in driver_list}
+            final_codes = order_leaderboard_codes(
+                [entry[0] for entry in driver_list], self.official_finish_order, True
+            )
+            driver_list = [by_code[code] for code in final_codes if code in by_code]
 
         self.last_leaderboard_order = [c for c, _, _, _ in driver_list]
         self.leaderboard_comp.set_entries(driver_list)

--- a/src/lib/leaderboard.py
+++ b/src/lib/leaderboard.py
@@ -1,0 +1,71 @@
+"""Leaderboard ordering helpers.
+
+These are deliberately free of any GUI (arcade) or FastF1 imports so the
+ordering policy can be unit tested headlessly and reused wherever a leaderboard
+order is needed.
+
+During a race the leaderboard is ordered by a live on-track progress proxy,
+which is a fine approximation of position while cars are running. Once the race
+is over that proxy is wrong: post-race penalties, lapped cars and retirements
+change the classified result without changing on-track progress. At that point
+the official classification from ``session.results`` should be used instead.
+See issue #309.
+"""
+
+from __future__ import annotations
+
+
+def official_finishing_order(results):
+    """Return driver abbreviations in official classified finishing order.
+
+    ``results`` is a FastF1 ``session.results`` DataFrame (or anything with the
+    same shape). Rows are ordered by the official ``Position`` column, which
+    already reflects post-race penalties, lapped cars and retirements (retired
+    drivers are classified at the back). Rows without a usable abbreviation are
+    skipped, and each code appears at most once.
+
+    Returns an empty list when no usable results are available, so callers can
+    treat "no official order" as "keep the live order".
+    """
+    if results is None:
+        return []
+    try:
+        if results.empty:
+            return []
+    except AttributeError:
+        return []
+
+    ordered = results
+    if "Position" in getattr(results, "columns", []):
+        # NaN positions (unclassified) sort to the end rather than the front.
+        ordered = results.sort_values("Position", na_position="last")
+
+    order = []
+    for _, row in ordered.iterrows():
+        code = str(row.get("Abbreviation", "") or "").strip()
+        if code and code not in order:
+            order.append(code)
+    return order
+
+
+def order_leaderboard_codes(progress_ranked_codes, official_finish_order, race_finished):
+    """Return the leaderboard code order to display for the current frame.
+
+    While the race is running (``race_finished`` is false) the live
+    ``progress_ranked_codes`` order, already sorted by on-track progress, is
+    returned unchanged. Once the race has finished the official classified
+    order is used instead so the final leaderboard matches the real result.
+
+    Codes present in the live order but missing from the official order are kept
+    and appended in their live order, so a driver is never dropped from the
+    board. Official codes that are not in the live order are ignored.
+    """
+    live = list(progress_ranked_codes)
+    if not race_finished or not official_finish_order:
+        return live
+
+    live_set = set(live)
+    ordered = [code for code in official_finish_order if code in live_set]
+    ordered_set = set(ordered)
+    ordered.extend(code for code in live if code not in ordered_set)
+    return ordered

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,89 @@
+"""Tests for the leaderboard ordering helpers (issue #309).
+
+These use small synthetic frames rather than live FastF1 data so they run
+offline and deterministically.
+"""
+
+import pandas as pd
+
+from src.lib.leaderboard import official_finishing_order, order_leaderboard_codes
+
+
+def _results(rows):
+    """Build a session.results-like DataFrame from (abbr, position, classified,
+    status) tuples."""
+    return pd.DataFrame(
+        [
+            {
+                "Abbreviation": abbr,
+                "Position": position,
+                "ClassifiedPosition": classified,
+                "Status": status,
+            }
+            for abbr, position, classified, status in rows
+        ]
+    )
+
+
+def test_official_order_follows_position_not_row_order():
+    # Rows deliberately out of Position order; a lapped car and a retirement
+    # are classified behind the finishers.
+    results = _results(
+        [
+            ("HAM", 3.0, "3", "Finished"),
+            ("VER", 1.0, "1", "Finished"),
+            ("ALO", 5.0, "5", "Lapped"),
+            ("NOR", 2.0, "2", "Finished"),
+            ("PIA", 4.0, "R", "Collision"),
+        ]
+    )
+    assert official_finishing_order(results) == ["VER", "NOR", "HAM", "PIA", "ALO"]
+
+
+def test_official_order_puts_unclassified_positions_last():
+    results = _results(
+        [
+            ("VER", 1.0, "1", "Finished"),
+            ("SAR", float("nan"), "R", "Accident"),
+            ("NOR", 2.0, "2", "Finished"),
+        ]
+    )
+    assert official_finishing_order(results) == ["VER", "NOR", "SAR"]
+
+
+def test_official_order_empty_or_none():
+    assert official_finishing_order(None) == []
+    assert official_finishing_order(pd.DataFrame()) == []
+
+
+def test_live_order_is_kept_while_race_running():
+    live = ["VER", "NOR", "HAM"]
+    official = ["HAM", "VER", "NOR"]
+    assert order_leaderboard_codes(live, official, race_finished=False) == live
+
+
+def test_official_order_used_once_race_finished():
+    live = ["VER", "NOR", "HAM"]  # live on-track proxy
+    official = ["HAM", "VER", "NOR"]  # e.g. after a penalty shuffles the order
+    assert order_leaderboard_codes(live, official, race_finished=True) == official
+
+
+def test_finished_without_official_order_keeps_live():
+    live = ["VER", "NOR", "HAM"]
+    assert order_leaderboard_codes(live, [], race_finished=True) == live
+
+
+def test_driver_missing_from_official_is_appended_not_dropped():
+    live = ["VER", "NOR", "HAM"]
+    official = ["NOR", "VER"]  # HAM missing from classification for some reason
+    assert order_leaderboard_codes(live, official, race_finished=True) == [
+        "NOR",
+        "VER",
+        "HAM",
+    ]
+
+
+def test_official_code_absent_from_live_is_ignored():
+    live = ["VER", "NOR"]
+    official = ["NOR", "GONE", "VER"]
+    assert order_leaderboard_codes(live, official, race_finished=True) == ["NOR", "VER"]


### PR DESCRIPTION
Fixes #309.

## What was happening

The sidebar leaderboard is rebuilt every frame in `race_replay.py` by sorting drivers on a live progress metric: `(lap - 1) * lap_length + projected_track_distance`, largest first. That is a fine proxy for position while the cars are running, but the same sort keeps running after the checkered flag. At the finish it cannot be right:

- post-race penalties change the classified order without changing on-track distance,
- lapped cars are ordered by raw projected distance rather than by laps down,
- once a car parks, its telemetry freezes, so the proxy gets noisy exactly when the order should be final.

I confirmed this against real data before writing anything. I ran the full 2024 Spanish GP through `get_race_telemetry` and looked at the last frame. The live order was:

```
HUL, SAI, HAM, OCO, VER, NOR, RUS, PIA, GAS, LEC, ...
```

The actual result was `VER, NOR, HAM, RUS, LEC, SAI, ...`, so the winner was being shown fifth and Hulkenberg was on top. That matches the report.

## How I approached it

My first instinct was to just re-sort in the draw method when the race is over, but that method lives inside the arcade window, which I cannot open headlessly on this machine, so I could not have tested it. So I pulled the ordering decision out into a small module with no arcade or FastF1 imports, `src/lib/leaderboard.py`:

- `official_finishing_order(results)` reads the classified order straight from `session.results`, which FastF1 already sorts by `Position` (that column reflects penalties, lapped cars and retirements, with retired drivers classified at the back).
- `order_leaderboard_codes(live_order, official_order, race_finished)` returns the live order untouched during the race, and the official order once it is over. It never drops a driver: anyone present live but missing from the classification is appended.

The window derives the official order once from `session.results` at startup and applies it only on the frozen final frame (`frame_index` at the last frame). Mid-race ordering is byte-for-byte unchanged, so there is no risk to the normal replay.

## Testing

- `tests/test_leaderboard.py` (8 cases) covers ordering by `Position` regardless of row order, retirements and unclassified rows sorting to the back, the live/finished switch, and the "never drop a driver" behaviour. Runs offline with synthetic frames.
- Verified `official_finishing_order` against real sessions: exact match on 2024 Spain, and on 2024 Australia the retirements (Hamilton, Verstappen) correctly land at the back.
- Ran the full 2024 Spain pipeline end to end: the live final-frame order differed from the result (as above) and the fix reproduced the official classification exactly.

I could not drive the arcade window itself without a display, so the rendering side is covered by the unit tests plus the end-to-end ordering check rather than by clicking through the GUI.

For transparency: I paired with Claude on this one. It was not fully autonomous, but the investigation, the design decision to keep the ordering testable, and the verification against real sessions were done together rather than blindly generated.
