### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tom Shaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Thanks to @el-mandaloriano for showing how to resolve this issue: #12
 
 ## 📝 License
 
-This project is licensed under the MIT License.
+This project is licensed under the [MIT License](LICENSE).
 
 ## ⚠️ Disclaimer
 


### PR DESCRIPTION
## Summary
The README states the project is licensed under MIT, but there's no LICENSE file at the repo root, so anyone wanting to reuse or attribute the project (like the person who opened #225) has nothing concrete to point to. This adds a standard MIT LICENSE file and links it from the README's License section instead of leaving it as plain text.

## Related issue
Closes #225

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor/maintenance
- [ ] Tests/tooling

## Testing
Docs-only change, nothing to run. Confirmed the LICENSE file renders correctly on GitHub and the README link resolves.

## Checklist
- [x] Changes are scoped to this issue
- [x] Tested locally (verified rendering)
- [x] Documentation updated (README license link)
- [x] No generated/cache files committed