### PR TITLE
feat: add Sector Times insight window (phase 1 of #317)

### DIFF
--- a/src/gui/insights_menu.py
+++ b/src/gui/insights_menu.py
@@ -79,6 +79,7 @@ class InsightsMenu(QMainWindow):
             "Race Analysis",
             [
                 ("Lap Time & Gap Evolution", "Lap time and gap trends per driver", self.launch_lap_time_chart),
+                ("Sector Times", "Per-lap sector breakdown with session & personal bests", self.launch_sector_times),
             ]
         ))
         
@@ -250,7 +251,10 @@ class InsightsMenu(QMainWindow):
     
     def launch_sector_times(self):
         print("🚀 Launching: Sector Times")
-        self.show_placeholder_message("Sector Times")
+        from src.insights.sector_times_window import SectorTimesWindow
+        window = SectorTimesWindow()
+        window.show()
+        self.opened_windows.append(window)
     
     def launch_lap_evolution(self):
         print("🚀 Launching: Lap Time & Gap Evolution")

--- a/src/insights/sector_times_window.py
+++ b/src/insights/sector_times_window.py
@@ -1,0 +1,347 @@
+"""
+Sector Times insight window.
+
+Shows a timing-screen-style breakdown of sector 1/2/3 times for every lap
+of a selected driver, coloured like the official F1 timing screens:
+
+- Purple: session best (fastest anyone has gone in that sector so far)
+- Green: personal best (driver's fastest in that sector so far)
+- White: no improvement
+
+Laps appear as the replay progresses, so the colouring always reflects the
+state of the session "so far" rather than leaking end-of-race information.
+Sector data comes from the ``lap_times`` payload broadcast by the replay
+server (official FastF1 lap data); frame-derived fallback laps without
+sector times are shown with dashes.
+"""
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QComboBox,
+    QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView
+)
+from PySide6.QtGui import QFont, QColor, QBrush
+from PySide6.QtCore import Qt
+
+from src.gui.pit_wall_window import PitWallWindow
+from src.lib.sectors import (
+    SECTOR_KEYS,
+    STATUS_SESSION_BEST,
+    STATUS_PERSONAL_BEST,
+    classify_sector_statuses,
+    session_best_holders,
+    best_sectors,
+    theoretical_best_s,
+)
+
+# Palette (consistent with the other insight windows)
+_BG = "#0f0f0f"
+_ROW_BG = "#1a1a1a"
+_ROW_ALT = "#141414"
+_HEADER_BG = "#111111"
+_TEXT = "#E0E0E0"
+_TEXT_DIM = "#888888"
+_BORDER = "#2a2a2a"
+
+# Timing screen colours
+_SESSION_BEST_COLOUR = "#B027C9"   # purple
+_PERSONAL_BEST_COLOUR = "#27C93F"  # green
+
+_COLUMNS = ("Lap", "Sector 1", "Sector 2", "Sector 3", "Lap Time")
+
+
+def _format_sector(seconds):
+    """Format a sector time in seconds as SS.mmm (or M:SS.mmm if over a minute)."""
+    if not isinstance(seconds, (int, float)) or seconds <= 0:
+        return "—"
+    if seconds >= 60:
+        m = int(seconds // 60)
+        return f"{m}:{seconds % 60:06.3f}"
+    return f"{seconds:.3f}"
+
+
+def _format_laptime(seconds):
+    """Format a lap time in seconds as M:SS.mmm."""
+    if not isinstance(seconds, (int, float)) or seconds <= 0:
+        return "—"
+    m = int(seconds // 60)
+    return f"{m}:{seconds % 60:06.3f}"
+
+
+class SectorTimesWindow(PitWallWindow):
+    """Pit wall insight showing per-lap sector times for a selected driver."""
+
+    def __init__(self):
+        self._lap_times = {}          # code -> [lap entry dicts]
+        self._known_drivers = []
+        self._selected_driver = None
+        self._current_time_s = None
+        self._leader_lap = 0
+        self._total_laps = 0
+        self._last_signature = None
+
+        super().__init__()
+
+        self.setWindowTitle("F1 Race Replay - Sector Times")
+        self.setGeometry(140, 140, 620, 640)
+
+    # ------------------------------------------------------------------ UI
+
+    def setup_ui(self):
+        central = QWidget()
+        central.setStyleSheet(f"background-color: {_BG};")
+        self.setCentralWidget(central)
+
+        root = QVBoxLayout(central)
+        root.setSpacing(8)
+        root.setContentsMargins(12, 12, 12, 12)
+
+        # Control row
+        ctrl = QHBoxLayout()
+        ctrl.setSpacing(8)
+
+        driver_label = QLabel("Driver:")
+        driver_label.setFont(QFont("Arial", 11))
+        driver_label.setStyleSheet(f"color: {_TEXT};")
+        ctrl.addWidget(driver_label)
+
+        self._driver_combo = QComboBox()
+        self._driver_combo.setMinimumWidth(120)
+        self._driver_combo.setFont(QFont("Arial", 11))
+        self._driver_combo.setPlaceholderText("Waiting for data…")
+        self._driver_combo.currentTextChanged.connect(self._on_driver_changed)
+        ctrl.addWidget(self._driver_combo)
+
+        ctrl.addStretch()
+
+        legend = QLabel(
+            f"<span style='color:{_SESSION_BEST_COLOUR};'>■</span> Session best   "
+            f"<span style='color:{_PERSONAL_BEST_COLOUR};'>■</span> Personal best"
+        )
+        legend.setFont(QFont("Arial", 10))
+        legend.setStyleSheet(f"color: {_TEXT_DIM};")
+        ctrl.addWidget(legend)
+
+        root.addLayout(ctrl)
+
+        # Session-best summary
+        self._session_best_label = QLabel("Waiting for lap data…")
+        self._session_best_label.setFont(QFont("Consolas", 10))
+        self._session_best_label.setStyleSheet(
+            f"color: {_TEXT}; background-color: {_HEADER_BG};"
+            f"border: 1px solid {_BORDER}; padding: 6px;"
+        )
+        root.addWidget(self._session_best_label)
+
+        # Lap table
+        self._table = QTableWidget(0, len(_COLUMNS))
+        self._table.setHorizontalHeaderLabels(_COLUMNS)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.setSelectionMode(QAbstractItemView.NoSelection)
+        self._table.setShowGrid(False)
+        self._table.setAlternatingRowColors(True)
+        self._table.setFont(QFont("Consolas", 10))
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Stretch)
+        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self._table.setStyleSheet(f"""
+            QTableWidget {{
+                background-color: {_ROW_BG};
+                alternate-background-color: {_ROW_ALT};
+                color: {_TEXT};
+                border: 1px solid {_BORDER};
+            }}
+            QHeaderView::section {{
+                background-color: {_HEADER_BG};
+                color: {_TEXT_DIM};
+                border: none;
+                border-bottom: 1px solid {_BORDER};
+                padding: 4px;
+                font-weight: bold;
+            }}
+        """)
+        root.addWidget(self._table, stretch=1)
+
+        # Personal summary for the selected driver
+        self._driver_summary_label = QLabel("")
+        self._driver_summary_label.setFont(QFont("Consolas", 10))
+        self._driver_summary_label.setStyleSheet(
+            f"color: {_TEXT}; background-color: {_HEADER_BG};"
+            f"border: 1px solid {_BORDER}; padding: 6px;"
+        )
+        root.addWidget(self._driver_summary_label)
+
+    # ----------------------------------------------------------- telemetry
+
+    def on_telemetry_data(self, data):
+        sd = data.get("session_data", {})
+        if sd:
+            time_s = sd.get("time_s")
+            if isinstance(time_s, (int, float)):
+                self._current_time_s = float(time_s)
+            leader_lap = sd.get("lap")
+            if isinstance(leader_lap, (int, float)):
+                self._leader_lap = int(leader_lap)
+            total_laps = sd.get("total_laps")
+            if isinstance(total_laps, (int, float)) and total_laps:
+                self._total_laps = int(total_laps)
+
+        if "lap_times" in data and data.get("lap_times"):
+            self._lap_times = data["lap_times"]
+
+        if not self._lap_times:
+            return
+
+        self._refresh_driver_list()
+
+        # Only rebuild the table when the set of visible laps changes —
+        # broadcasts arrive every frame, so rebuilding each time would
+        # waste CPU redrawing an identical table.
+        visible = self._visible_entries_by_code()
+        signature = tuple(sorted(
+            (code, int(entry["lap"]))
+            for code, entries in visible.items()
+            for entry in entries
+        ))
+        if signature != self._last_signature:
+            self._last_signature = signature
+            self._rebuild(visible)
+
+    # ------------------------------------------------------------- helpers
+
+    def _entry_visible(self, entry):
+        """Mirror the lap chart's reveal logic: a lap only appears once the
+        replay has reached the moment the driver completed it."""
+        if entry.get("is_terminal_lap"):
+            return False
+        visible_at_s = None
+        for key in ("replay_line_time_s", "replay_end_time_s"):
+            value = entry.get(key)
+            if isinstance(value, (int, float)):
+                visible_at_s = float(value)
+                break
+        if visible_at_s is None and (
+            entry.get("time_source") == "frame_backfill"
+            or entry.get("source") == "derived"
+        ):
+            for key in ("line_time_s", "end_time_s"):
+                value = entry.get(key)
+                if isinstance(value, (int, float)):
+                    visible_at_s = float(value)
+                    break
+        if visible_at_s is not None and isinstance(self._current_time_s, (int, float)):
+            return self._current_time_s >= visible_at_s
+        lap = entry.get("lap")
+        if isinstance(lap, (int, float)):
+            return self._leader_lap > int(lap)
+        return False
+
+    def _visible_entries_by_code(self):
+        visible = {}
+        for code, entries in self._lap_times.items():
+            shown = [e for e in entries if self._entry_visible(e)]
+            if shown:
+                visible[code] = shown
+        return visible
+
+    def _refresh_driver_list(self):
+        incoming = sorted(self._lap_times.keys())
+        if incoming == self._known_drivers:
+            return
+        current = self._driver_combo.currentText()
+        self._driver_combo.blockSignals(True)
+        self._driver_combo.clear()
+        self._driver_combo.addItems(incoming)
+        if current in incoming:
+            self._driver_combo.setCurrentText(current)
+        elif incoming:
+            self._driver_combo.setCurrentIndex(0)
+        self._driver_combo.blockSignals(False)
+        self._known_drivers = incoming
+        self._selected_driver = self._driver_combo.currentText() or None
+
+    def _on_driver_changed(self, text):
+        if not text or text == self._selected_driver:
+            return
+        self._selected_driver = text
+        self._last_signature = None  # force rebuild on next update
+        self._rebuild(self._visible_entries_by_code())
+
+    # ------------------------------------------------------------ rendering
+
+    def _rebuild(self, visible):
+        statuses = classify_sector_statuses(visible)
+        self._update_session_best_label(visible)
+
+        code = self._selected_driver
+        entries = sorted(
+            visible.get(code, []),
+            key=lambda e: e.get("lap", 0),
+        )
+
+        self._table.setRowCount(len(entries))
+        for row_idx, entry in enumerate(entries):
+            lap = int(entry.get("lap", 0))
+
+            lap_text = str(lap)
+            if entry.get("is_pit_entry"):
+                lap_text += "  (in)"
+            elif entry.get("is_out_lap"):
+                lap_text += "  (out)"
+            lap_item = QTableWidgetItem(lap_text)
+            lap_item.setTextAlignment(Qt.AlignCenter)
+            if entry.get("is_pit_entry") or entry.get("is_out_lap"):
+                lap_item.setForeground(QBrush(QColor(_TEXT_DIM)))
+            self._table.setItem(row_idx, 0, lap_item)
+
+            entry_statuses = statuses.get((code, lap), {})
+            for col_offset, key in enumerate(SECTOR_KEYS):
+                item = QTableWidgetItem(_format_sector(entry.get(key)))
+                item.setTextAlignment(Qt.AlignCenter)
+                status = entry_statuses.get(key)
+                if status == STATUS_SESSION_BEST:
+                    item.setForeground(QBrush(QColor(_SESSION_BEST_COLOUR)))
+                    font = item.font()
+                    font.setBold(True)
+                    item.setFont(font)
+                elif status == STATUS_PERSONAL_BEST:
+                    item.setForeground(QBrush(QColor(_PERSONAL_BEST_COLOUR)))
+                self._table.setItem(row_idx, 1 + col_offset, item)
+
+            time_item = QTableWidgetItem(_format_laptime(entry.get("time_s")))
+            time_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row_idx, len(_COLUMNS) - 1, time_item)
+
+        self._table.scrollToBottom()
+        self._update_driver_summary(entries)
+
+    def _update_session_best_label(self, visible):
+        holders = session_best_holders(visible)
+        parts = []
+        for idx, key in enumerate(SECTOR_KEYS, start=1):
+            best, codes = holders[key]
+            if best is None:
+                parts.append(f"S{idx} —")
+            else:
+                parts.append(f"S{idx} {_format_sector(best)} ({'/'.join(codes)})")
+        self._session_best_label.setText("Session best:   " + "   ·   ".join(parts))
+
+    def _update_driver_summary(self, entries):
+        if not entries:
+            self._driver_summary_label.setText("No completed laps yet for this driver.")
+            return
+        bests = best_sectors(entries)
+        parts = []
+        for idx, key in enumerate(SECTOR_KEYS, start=1):
+            parts.append(f"S{idx} {_format_sector(bests[key])}")
+        ideal = theoretical_best_s(entries)
+        best_lap = min(
+            (e.get("time_s") for e in entries
+             if isinstance(e.get("time_s"), (int, float)) and e.get("time_s") > 0),
+            default=None,
+        )
+        self._driver_summary_label.setText(
+            "Personal best:  " + "   ·   ".join(parts)
+            + f"   ·   Best lap {_format_laptime(best_lap)}"
+            + f"   ·   Ideal lap {_format_laptime(ideal)}"
+        )

--- a/src/interfaces/race_replay.py
+++ b/src/interfaces/race_replay.py
@@ -352,6 +352,10 @@ class F1RaceReplayWindow(arcade.Window):
                 import fastf1.utils as ffutils
                 from src.lib.tyres import get_tyre_compound_int
                 result = {}
+
+                def _sector_seconds(value):
+                    return float(value.total_seconds()) if pd.notna(value) else None
+
                 for _, row in session.laps.iterrows():
                     code = row.get("Driver")
                     lap_num = row.get("LapNumber")
@@ -391,6 +395,9 @@ class F1RaceReplayWindow(arcade.Window):
                         "line_time_s": float(line_end_s) if line_end_s is not None else None,
                         "tyre": tyre_int,
                         "tyre_life": t_life,
+                        "sector1_s": _sector_seconds(row.get("Sector1Time")),
+                        "sector2_s": _sector_seconds(row.get("Sector2Time")),
+                        "sector3_s": _sector_seconds(row.get("Sector3Time")),
                         "is_pit_entry": is_pit_entry,
                         "is_pit_affected": is_pit_entry,
                         "is_out_lap": is_out_lap,

--- a/src/lib/sectors.py
+++ b/src/lib/sectors.py
@@ -1,0 +1,112 @@
+"""
+Helpers for per-lap sector time analysis.
+
+These functions operate on the lap entry dictionaries broadcast by the
+replay server (see ``F1RaceReplayWindow._compute_lap_times``), where each
+entry may carry ``sector1_s`` / ``sector2_s`` / ``sector3_s`` values in
+seconds. Entries without sector data (frame-derived fallback laps, DNF
+marker rows) are tolerated everywhere.
+"""
+
+SECTOR_KEYS = ("sector1_s", "sector2_s", "sector3_s")
+
+# Classification statuses, mirroring official F1 timing screen colours:
+# purple = fastest of the session, green = personal best, no colour otherwise.
+STATUS_SESSION_BEST = "session_best"
+STATUS_PERSONAL_BEST = "personal_best"
+STATUS_NONE = "none"
+
+
+def _valid_time(value):
+    """Return the value as a float if it is a usable sector time, else None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def best_sectors(entries):
+    """
+    Return the best time for each sector across a list of lap entries.
+
+    Returns {"sector1_s": float|None, "sector2_s": float|None, "sector3_s": float|None}.
+    """
+    result = {}
+    for key in SECTOR_KEYS:
+        times = [t for t in (_valid_time(e.get(key)) for e in entries) if t is not None]
+        result[key] = min(times) if times else None
+    return result
+
+
+def theoretical_best_s(entries):
+    """
+    Sum of a driver's best individual sector times ("ideal lap").
+
+    Returns None unless a valid time exists for all three sectors.
+    """
+    bests = best_sectors(entries)
+    if any(bests[key] is None for key in SECTOR_KEYS):
+        return None
+    return sum(bests[key] for key in SECTOR_KEYS)
+
+
+def classify_sector_statuses(entries_by_code):
+    """
+    Classify every sector time as session best, personal best, or neither.
+
+    Args:
+        entries_by_code: {driver_code: [lap entry dict, ...]} — typically the
+            subset of lap entries currently visible in the replay, so that the
+            colouring reflects the state of the session "so far".
+
+    Returns:
+        {(driver_code, lap): {"sector1_s": status, "sector2_s": status,
+        "sector3_s": status}} where status is one of STATUS_SESSION_BEST,
+        STATUS_PERSONAL_BEST, STATUS_NONE.
+    """
+    all_entries = [e for entries in entries_by_code.values() for e in entries]
+    session_best = best_sectors(all_entries)
+
+    result = {}
+    for code, entries in entries_by_code.items():
+        personal_best = best_sectors(entries)
+        for entry in entries:
+            lap = entry.get("lap")
+            if lap is None:
+                continue
+            statuses = {}
+            for key in SECTOR_KEYS:
+                value = _valid_time(entry.get(key))
+                if value is None:
+                    statuses[key] = STATUS_NONE
+                elif session_best[key] is not None and value <= session_best[key]:
+                    statuses[key] = STATUS_SESSION_BEST
+                elif personal_best[key] is not None and value <= personal_best[key]:
+                    statuses[key] = STATUS_PERSONAL_BEST
+                else:
+                    statuses[key] = STATUS_NONE
+            result[(code, int(lap))] = statuses
+    return result
+
+
+def session_best_holders(entries_by_code):
+    """
+    Return, for each sector, the best time and the driver(s) who set it.
+
+    Returns {"sector1_s": (time|None, [codes]), ...}. The code list is empty
+    when no valid time exists for that sector.
+    """
+    all_entries = [e for entries in entries_by_code.values() for e in entries]
+    session_best = best_sectors(all_entries)
+
+    result = {}
+    for key in SECTOR_KEYS:
+        best = session_best[key]
+        holders = []
+        if best is not None:
+            for code, entries in entries_by_code.items():
+                if any(_valid_time(e.get(key)) == best for e in entries):
+                    holders.append(code)
+        result[key] = (best, sorted(holders))
+    return result

--- a/telemetry.md
+++ b/telemetry.md
@@ -97,6 +97,20 @@ The `safety_car` field in each frame contains the simulated Safety Car position 
 
 > **Note:** The Safety Car position is simulated (placed ~500m ahead of the race leader) since the F1 API does not provide real SC GPS data. The `phase` field is useful for triggering visual effects in custom tools.
 
+### Sector Times
+
+Each entry in the `lap_times` payload carries the three sector times for that lap, in seconds:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sector1_s` | float \| null | Sector 1 time in seconds |
+| `sector2_s` | float \| null | Sector 2 time in seconds |
+| `sector3_s` | float \| null | Sector 3 time in seconds |
+
+These come from official FastF1 lap data. A field is `null` when the timing feed has no sector time for that lap — most commonly the opening lap of a session, laps interrupted by a red flag, and laps reconstructed from frame data rather than official timing. Consumers should treat `null` as "unknown" rather than zero.
+
+`src/lib/sectors.py` provides helpers for working with these values: `best_sectors`, `theoretical_best_s` (ideal-lap sum), `classify_sector_statuses` (session best / personal best colouring), and `session_best_holders`.
+
 ## Technical Details
 
 - **Protocol**: TCP socket on `localhost:9999`

--- a/tests/lib/test_sectors.py
+++ b/tests/lib/test_sectors.py
@@ -1,0 +1,122 @@
+import pytest
+
+from src.lib.sectors import (
+    SECTOR_KEYS,
+    STATUS_NONE,
+    STATUS_PERSONAL_BEST,
+    STATUS_SESSION_BEST,
+    best_sectors,
+    classify_sector_statuses,
+    session_best_holders,
+    theoretical_best_s,
+)
+
+
+def _entry(lap, s1=None, s2=None, s3=None, **extra):
+    entry = {"lap": lap, "sector1_s": s1, "sector2_s": s2, "sector3_s": s3}
+    entry.update(extra)
+    return entry
+
+
+class TestBestSectors:
+    def test_picks_minimum_per_sector(self):
+        entries = [
+            _entry(1, 30.0, 40.0, 25.0),
+            _entry(2, 29.5, 41.0, 24.8),
+            _entry(3, 31.0, 39.2, 26.0),
+        ]
+        assert best_sectors(entries) == {
+            "sector1_s": 29.5,
+            "sector2_s": 39.2,
+            "sector3_s": 24.8,
+        }
+
+    def test_ignores_missing_and_invalid_values(self):
+        entries = [
+            _entry(1, None, 40.0, 0.0),
+            _entry(2, -5.0, 41.0, None),
+        ]
+        result = best_sectors(entries)
+        assert result["sector1_s"] is None
+        assert result["sector2_s"] == 40.0
+        assert result["sector3_s"] is None
+
+    def test_empty_entries(self):
+        assert best_sectors([]) == {key: None for key in SECTOR_KEYS}
+
+
+class TestTheoreticalBest:
+    def test_sums_best_sectors_across_laps(self):
+        entries = [
+            _entry(1, 30.0, 40.0, 25.0),
+            _entry(2, 29.5, 41.0, 24.8),
+        ]
+        assert theoretical_best_s(entries) == pytest.approx(29.5 + 40.0 + 24.8)
+
+    def test_none_when_a_sector_is_never_set(self):
+        entries = [_entry(1, 30.0, 40.0, None)]
+        assert theoretical_best_s(entries) is None
+
+
+class TestClassifySectorStatuses:
+    def test_session_best_beats_personal_best(self):
+        data = {
+            "VER": [_entry(1, 30.0, 40.0, 25.0)],
+            "HAM": [_entry(1, 29.0, 41.0, 26.0)],
+        }
+        statuses = classify_sector_statuses(data)
+        # HAM holds the session best in S1, VER in S2 and S3
+        assert statuses[("HAM", 1)]["sector1_s"] == STATUS_SESSION_BEST
+        assert statuses[("VER", 1)]["sector2_s"] == STATUS_SESSION_BEST
+        assert statuses[("VER", 1)]["sector3_s"] == STATUS_SESSION_BEST
+        # VER's S1 is his personal best but not the session best
+        assert statuses[("VER", 1)]["sector1_s"] == STATUS_PERSONAL_BEST
+
+    def test_slower_lap_is_not_flagged(self):
+        data = {
+            "VER": [
+                _entry(1, 30.0, 40.0, 25.0),
+                _entry(2, 31.0, 42.0, 26.0),
+            ],
+        }
+        statuses = classify_sector_statuses(data)
+        assert statuses[("VER", 2)] == {key: STATUS_NONE for key in SECTOR_KEYS}
+        # The single-driver fastest lap is both personal and session best;
+        # session best takes precedence.
+        assert statuses[("VER", 1)] == {key: STATUS_SESSION_BEST for key in SECTOR_KEYS}
+
+    def test_tied_session_best_flags_both_drivers(self):
+        data = {
+            "VER": [_entry(1, 30.0, 40.0, 25.0)],
+            "HAM": [_entry(1, 30.0, 41.0, 26.0)],
+        }
+        statuses = classify_sector_statuses(data)
+        assert statuses[("VER", 1)]["sector1_s"] == STATUS_SESSION_BEST
+        assert statuses[("HAM", 1)]["sector1_s"] == STATUS_SESSION_BEST
+
+    def test_missing_sector_times_are_none_status(self):
+        data = {"VER": [_entry(1, None, 40.0, -1.0)]}
+        statuses = classify_sector_statuses(data)
+        assert statuses[("VER", 1)]["sector1_s"] == STATUS_NONE
+        assert statuses[("VER", 1)]["sector3_s"] == STATUS_NONE
+        assert statuses[("VER", 1)]["sector2_s"] == STATUS_SESSION_BEST
+
+    def test_entries_without_lap_number_are_skipped(self):
+        data = {"VER": [{"sector1_s": 30.0, "sector2_s": 40.0, "sector3_s": 25.0}]}
+        assert classify_sector_statuses(data) == {}
+
+
+class TestSessionBestHolders:
+    def test_returns_time_and_holders(self):
+        data = {
+            "VER": [_entry(1, 30.0, 40.0, 25.0)],
+            "HAM": [_entry(1, 30.0, 39.0, 26.0)],
+        }
+        holders = session_best_holders(data)
+        assert holders["sector1_s"] == (30.0, ["HAM", "VER"])
+        assert holders["sector2_s"] == (39.0, ["HAM"])
+        assert holders["sector3_s"] == (25.0, ["VER"])
+
+    def test_empty_data(self):
+        holders = session_best_holders({})
+        assert holders == {key: (None, []) for key in SECTOR_KEYS}

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -15,6 +15,7 @@ MODULES = [
     "src.insights.driver_telemetry_window",
     "src.insights.example_pit_wall_window",
     "src.insights.race_control_feed_window",
+    "src.insights.sector_times_window",
     "src.insights.telemetry_stream_viewer",
     "src.insights.track_position_window",
     "src.insights.tyre_strategy_window",


### PR DESCRIPTION
## Summary

Adds a **Sector Times** insight window showing a timing-screen-style S1/S2/S3 breakdown for every lap of a selected driver, coloured like the official F1 timing screens - purple for session best, green for personal best.

This is the **sector-level (phase 1)** half of #317. That issue proposes sector-level first and minisector-level as a fast-follow, so this deliberately stops at sector granularity and leaves minisectors for a follow-up.

The data was already there but unused: `Sector1Time`/`2`/`3` were only read to label the single fastest qualifying lap. This surfaces them for every lap of the race.

Three pieces:

- **`src/lib/sectors.py`** (new) - pure helpers: `best_sectors`, `theoretical_best_s` (ideal-lap sum), `classify_sector_statuses` (session/personal best), `session_best_holders`. No Qt or I/O, so it's directly unit-testable.
- **`src/interfaces/race_replay.py`** - attaches `sector1_s`/`sector2_s`/`sector3_s` to each entry in the broadcast `lap_times` payload (3 lines).
- **`src/insights/sector_times_window.py`** (new) - a `PitWallWindow` following the same pattern as `tyre_strategy_window.py` / `lap_time_chart_window.py`, wired into the existing `launch_sector_times` hook that previously showed the "Coming Soon" placeholder.

Two details worth calling out for review:

- **No result leaking.** Laps are revealed as the replay reaches them, reusing the same visibility rule as `lap_time_chart_window.py`, so the purple/green colouring reflects the session *so far* rather than the finished race.
- **Missing sector data is handled.** Opening laps, red-flag-interrupted laps, and frame-derived fallback laps have no official sector times; those render as `-` rather than `0.000`. On the 2024 Bahrain GP that's 21 of 1129 laps.

## Related issue

Part of #317 (phase 1: sector-level). Not using `Closes` since minisector granularity from that issue is still outstanding.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / maintenance
- [x] Tests / tooling

## Testing

    python -m pytest

85 passed (20 of them new, covering the `src/lib/sectors.py` helpers: tie-breaking on equal session bests, missing/invalid sector values, entries with no lap number, and the ideal-lap sum).

Beyond the unit tests I verified end-to-end against real data (2024 Bahrain GP, `_compute_lap_times` against a live FastF1 session):

- Verstappen holds all three session-best sectors; ideal lap 1:32.608, matching his fastest lap.
- Classification totals came out to exactly 3 session bests + 57 personal bests, i.e. 20 drivers x 3 sectors - 3, which is the arithmetic that should hold if the logic is correct.
- Rendered the widget offscreen and sampled pixels to confirm non-best sector text draws at the theme foreground colour on the dark row background.

## Checklist

- [x] I have kept the change focused and easy to review.
- [x] I have tested the affected behavior locally.
- [x] I have updated documentation where needed.
- [x] I have avoided committing generated files, caches, or local environment files.

---

Happy to adjust the colour constants, column layout, or split the `src/lib/sectors.py` helpers differently if you'd prefer them to live elsewhere. I can also follow up with the minisector view from #317 if this direction looks right.

Two small things I noticed but deliberately left out to keep this reviewable:
- The "Active Insights" list in `docs/InsightsMenu.md` is stale (lists 2 windows; the menu registers 8). Happy to send that as a separate docs PR.
- `insights_menu.py` still has several unused `launch_*` placeholder methods.
